### PR TITLE
fix(site): only parse templates

### DIFF
--- a/server/site/site.go
+++ b/server/site/site.go
@@ -20,7 +20,7 @@ func NewFS() *embed.FS {
 
 // NewPatterns for site.
 func NewPatterns() mvc.Patterns {
-	return mvc.Patterns{"**/*.tmpl", "**/*.yaml"}
+	return mvc.Patterns{"**/*.tmpl"}
 }
 
 // Register for site.


### PR DESCRIPTION
Do not need YAML files.