### PR TITLE
fix(site): prevent root route from matching missing pages

### DIFF
--- a/internal/site/books/view/books.tmpl
+++ b/internal/site/books/view/books.tmpl
@@ -21,7 +21,7 @@
         {{range .Model.Books}}
           <tr>
             <td>{{.Title}}</td>
-            <td><a href="{{.Link}}" target=”_blank”>{{.Link}}</a></td>
+            <td><a href="{{.Link}}" target="_blank" rel="noopener noreferrer">{{.Link}}</a></td>
           </tr>
         {{end}}
       </tbody>

--- a/internal/site/root/layout/full.tmpl
+++ b/internal/site/root/layout/full.tmpl
@@ -16,7 +16,7 @@
         <ul>
           <li><a hx-put="/" hx-target="#main" hx-push-url="true">Home</a></li>
           <li><a hx-put="/books" hx-target="#main" hx-push-url="true">Books</a></li>
-          <li><a href="https://github.com/Lean-Thoughts" target=”_blank”>Code</a></li>
+          <li><a href="https://github.com/Lean-Thoughts" target="_blank" rel="noopener noreferrer">Code</a></li>
         </ul>
       </nav>
     </header>

--- a/internal/site/root/route/route.go
+++ b/internal/site/root/route/route.go
@@ -11,6 +11,6 @@ import (
 func Register(info *meta.Info) {
 	view, partialView := view.NewRoot()
 
-	mvc.Get("/", controller.NewRoot(info, view))
-	mvc.Put("/", controller.NewRoot(info, partialView))
+	mvc.Get("/{$}", controller.NewRoot(info, view))
+	mvc.Put("/{$}", controller.NewRoot(info, partialView))
 }

--- a/internal/site/root/view/root.tmpl
+++ b/internal/site/root/view/root.tmpl
@@ -12,7 +12,7 @@
     </p>
     <footer>
       <small>
-        <a href="mailto:af@lean-thoughts.com" target=”_blank”>Reach out</a>
+        <a href="mailto:af@lean-thoughts.com" target="_blank" rel="noopener noreferrer">Reach out</a>
       </small>
     </footer>
   </article>

--- a/test/features/site/site.feature
+++ b/test/features/site/site.feature
@@ -8,8 +8,10 @@ Feature: Web
     Examples:
       | layout  | section |
       | full    | root    |
-      | full    | home    |
       | full    | books   |
       | partial | root    |
-      | partial | home    |
       | partial | books   |
+
+  Scenario: Missing section
+    When I visit a missing section
+    Then I should see the page is missing

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -20,10 +20,22 @@ Then('I should see {string}') do |section|
 
   expected = {
     'root' => 'Vince Lombardi',
-    'home' => 'Vince Lombardi',
     'books' => 'Margaret Fuller'
   }
   html = Nokogiri::HTML.parse(@response.body)
 
   expect(html.text).to include(expected[section])
+end
+
+When('I visit a missing section') do
+  opts = {
+    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' },
+    read_timeout: 10, open_timeout: 10
+  }
+
+  @response = Web::V1.http.get_missing(opts)
+end
+
+Then('I should see the page is missing') do
+  expect(@response.code).to eq(404)
 end

--- a/test/lib/web/v1/http.rb
+++ b/test/lib/web/v1/http.rb
@@ -38,25 +38,6 @@ module Web
         put('/', opts)
       end
 
-      # GET the home page.
-      #
-      # Note: whether `/home` is distinct from `/` is determined by the running
-      # service; this helper exists because the test suite exercises it.
-      #
-      # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#get}
-      # @return [Object] the response returned by the underlying HTTP client
-      def get_home(opts = {})
-        get('/home', opts)
-      end
-
-      # PUT the home page, typically used to request a partial/fragment render.
-      #
-      # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#put}
-      # @return [Object] the response returned by the underlying HTTP client
-      def put_home(opts = {})
-        put('/home', opts)
-      end
-
       # GET the books page.
       #
       # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#get}
@@ -71,6 +52,14 @@ module Web
       # @return [Object] the response returned by the underlying HTTP client
       def put_books(opts = {})
         put('/books', opts)
+      end
+
+      # GET a route that should not be handled by the site.
+      #
+      # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#get}
+      # @return [Object] the response returned by the underlying HTTP client
+      def get_missing(opts = {})
+        get('/not-a-real-page', opts)
       end
     end
   end


### PR DESCRIPTION
## What
- constrain the root route to exact `/` matching so missing pages return 404
- remove the unused `/home` acceptance-test surface
- correct new-tab link attributes and add `rel="noopener noreferrer"`

## Why
- avoid serving the home page for arbitrary paths
- keep the public route surface limited to documented endpoints
- make external link attributes valid and safer

## Testing
- `make lint`
- `make features`
- `make benchmarks`
