### PR TITLE
feat(site): render missing pages through mvc

### DIFF
--- a/internal/site/errors/controller/controller.go
+++ b/internal/site/errors/controller/controller.go
@@ -1,0 +1,25 @@
+package controller
+
+import (
+	"github.com/alexfalkowski/go-service/v2/context"
+	"github.com/alexfalkowski/go-service/v2/net/http"
+	"github.com/alexfalkowski/go-service/v2/net/http/meta"
+	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
+	"github.com/alexfalkowski/web/internal/site/errors/model"
+	site "github.com/alexfalkowski/web/internal/site/meta"
+)
+
+// NewNotFound controller.
+func NewNotFound(info *site.Info, view *mvc.View, partialView *mvc.View) mvc.NotFoundController[model.NotFound] {
+	return func(ctx context.Context) (*mvc.View, *model.NotFound) {
+		notFound := &model.NotFound{Info: info}
+		req := meta.Request(ctx)
+
+		switch req.Method {
+		case http.MethodPut:
+			return partialView, notFound
+		default:
+			return view, notFound
+		}
+	}
+}

--- a/internal/site/errors/controller/doc.go
+++ b/internal/site/errors/controller/doc.go
@@ -1,0 +1,14 @@
+// Package controller defines MVC controllers for the error feature.
+//
+// Controllers in this package are responsible for assembling the model data
+// required by error views. They choose between full-page and partial views based
+// on the request method.
+//
+// # Public API
+//
+// NewNotFound constructs an MVC not-found controller that populates the error
+// model with shared site metadata and returns the appropriate view.
+//
+// This package is typically wired via dependency injection by the error route
+// registration rather than being used directly by consumers.
+package controller

--- a/internal/site/errors/doc.go
+++ b/internal/site/errors/doc.go
@@ -1,0 +1,15 @@
+// Package errors wires the site's error feature.
+//
+// The error feature provides the MVC not-found renderer used when no route
+// matches a request. It is composed into the wider site using dependency
+// injection.
+//
+// Consumers typically do not call into this package directly. Instead, they
+// include `site.Module`, which includes `errors.Module` and thereby installs the
+// not-found registration.
+//
+// # Public API
+//
+// The public API of this package is `Module`, a DI module that installs the
+// error feature into the application.
+package errors

--- a/internal/site/errors/model/doc.go
+++ b/internal/site/errors/model/doc.go
@@ -1,0 +1,2 @@
+// Package model defines view models for the error feature.
+package model

--- a/internal/site/errors/model/model.go
+++ b/internal/site/errors/model/model.go
@@ -1,0 +1,8 @@
+package model
+
+import "github.com/alexfalkowski/web/internal/site/meta"
+
+// NotFound model.
+type NotFound struct {
+	Info *meta.Info
+}

--- a/internal/site/errors/module.go
+++ b/internal/site/errors/module.go
@@ -1,0 +1,11 @@
+package errors
+
+import (
+	"github.com/alexfalkowski/go-service/v2/di"
+	"github.com/alexfalkowski/web/internal/site/errors/route"
+)
+
+// Module for fx.
+var Module = di.Module(
+	route.Module,
+)

--- a/internal/site/errors/route/doc.go
+++ b/internal/site/errors/route/doc.go
@@ -1,0 +1,2 @@
+// Package route registers routes for the error feature.
+package route

--- a/internal/site/errors/route/module.go
+++ b/internal/site/errors/route/module.go
@@ -1,0 +1,8 @@
+package route
+
+import "github.com/alexfalkowski/go-service/v2/di"
+
+// Module for fx.
+var Module = di.Module(
+	di.Register(Register),
+)

--- a/internal/site/errors/route/route.go
+++ b/internal/site/errors/route/route.go
@@ -1,0 +1,15 @@
+package route
+
+import (
+	"github.com/alexfalkowski/go-service/v2/net/http/mvc"
+	"github.com/alexfalkowski/web/internal/site/errors/controller"
+	"github.com/alexfalkowski/web/internal/site/errors/view"
+	"github.com/alexfalkowski/web/internal/site/meta"
+)
+
+// Register not found.
+func Register(info *meta.Info) {
+	view, partialView := view.NewNotFound()
+
+	mvc.NotFound(controller.NewNotFound(info, view, partialView))
+}

--- a/internal/site/errors/view/doc.go
+++ b/internal/site/errors/view/doc.go
@@ -1,0 +1,2 @@
+// Package view defines MVC views for the error feature.
+package view

--- a/internal/site/errors/view/not_found.tmpl
+++ b/internal/site/errors/view/not_found.tmpl
@@ -1,0 +1,8 @@
+{{ define "content" }}
+  <article>
+    <h2>Page not found</h2>
+    <p>
+      The page you requested could not be found.
+    </p>
+  </article>
+{{ end }}

--- a/internal/site/errors/view/view.go
+++ b/internal/site/errors/view/view.go
@@ -1,0 +1,8 @@
+package view
+
+import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
+
+// NewNotFound view.
+func NewNotFound() (*mvc.View, *mvc.View) {
+	return mvc.NewViewPair("errors/view/not_found.tmpl")
+}

--- a/internal/site/module.go
+++ b/internal/site/module.go
@@ -3,6 +3,7 @@ package site
 import (
 	"github.com/alexfalkowski/go-service/v2/di"
 	"github.com/alexfalkowski/web/internal/site/books"
+	"github.com/alexfalkowski/web/internal/site/errors"
 	"github.com/alexfalkowski/web/internal/site/meta"
 	"github.com/alexfalkowski/web/internal/site/robots"
 	"github.com/alexfalkowski/web/internal/site/root"
@@ -12,6 +13,7 @@ import (
 var Module = di.Module(
 	meta.Module,
 	books.Module,
+	errors.Module,
 	robots.Module,
 	root.Module,
 	di.Constructor(NewFileSystem),

--- a/internal/site/site.go
+++ b/internal/site/site.go
@@ -9,6 +9,7 @@ import (
 
 //go:embed root/layout/*.tmpl
 //go:embed root/view/*.tmpl
+//go:embed errors/view/*.tmpl
 //go:embed books/view/*.tmpl
 //go:embed books/repository/*.yaml
 var filesystem embed.FS

--- a/test/features/site/site.feature
+++ b/test/features/site/site.feature
@@ -12,6 +12,11 @@ Feature: Web
       | partial | root    |
       | partial | books   |
 
-  Scenario: Missing section
-    When I visit a missing section
-    Then I should see the page is missing
+  Scenario Outline: Missing section
+    When I visit a missing section with layout "<layout>"
+    Then I should see the page is missing with layout "<layout>"
+
+    Examples:
+      | layout  |
+      | full    |
+      | partial |

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -2,7 +2,7 @@
 
 When('I visit {string} with layout {string}') do |section, layout|
   opts = {
-    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' },
+    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0', accept: 'text/html' },
     read_timeout: 10, open_timeout: 10
   }
   methods = {
@@ -27,15 +27,31 @@ Then('I should see {string}') do |section|
   expect(html.text).to include(expected[section])
 end
 
-When('I visit a missing section') do
+When('I visit a missing section with layout {string}') do |layout|
+  headers = { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' }
+  layout_headers = {
+    'full' => { accept: 'text/html' },
+    'partial' => { hx_request: 'true' }
+  }
   opts = {
-    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' },
+    headers: headers.merge(layout_headers[layout]),
     read_timeout: 10, open_timeout: 10
   }
+  methods = {
+    'full' => 'get',
+    'partial' => 'put'
+  }
+  method = methods[layout]
 
-  @response = Web::V1.http.get_missing(opts)
+  @response = Web::V1.http.send("#{method}_missing", opts)
 end
 
-Then('I should see the page is missing') do
+Then('I should see the page is missing with layout {string}') do |layout|
   expect(@response.code).to eq(404)
+  expect(@response.headers[:content_type]).to eq('text/html; charset=utf-8')
+
+  html = Nokogiri::HTML.parse(@response.body)
+
+  expect(html.text).to include('Page not found')
+  expect(html.text.include?('Copyright')).to eq(layout == 'full')
 end

--- a/test/lib/web/v1/http.rb
+++ b/test/lib/web/v1/http.rb
@@ -35,7 +35,7 @@ module Web
       # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#put}
       # @return [Object] the response returned by the underlying HTTP client
       def put_root(opts = {})
-        put('/', opts)
+        put('/', nil, opts)
       end
 
       # GET the books page.
@@ -51,7 +51,7 @@ module Web
       # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#put}
       # @return [Object] the response returned by the underlying HTTP client
       def put_books(opts = {})
-        put('/books', opts)
+        put('/books', nil, opts)
       end
 
       # GET a route that should not be handled by the site.
@@ -60,6 +60,14 @@ module Web
       # @return [Object] the response returned by the underlying HTTP client
       def get_missing(opts = {})
         get('/not-a-real-page', opts)
+      end
+
+      # PUT a route that should not be handled by the site.
+      #
+      # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#put}
+      # @return [Object] the response returned by the underlying HTTP client
+      def put_missing(opts = {})
+        put('/not-a-real-page', nil, opts)
       end
     end
   end


### PR DESCRIPTION
## What

- add an MVC not-found feature under internal/site/errors with full and partial rendering
- embed the not-found template and register the errors module with the site module
- cover missing full and partial page requests in the Cucumber suite, including HTMX headers for partial requests
- fix PUT test helpers so request options are passed as options instead of payload

## Why

Missing page requests should use the MVC not-found handler added in go-service, preserving the full layout for browser requests and partial content for HTMX requests.

## Testing

- go test ./...
- make lint
- make features

AI-assisted-by: [Codex](https://openai.com/codex/)
