### PR TITLE
feat(robots): serve crawler rules from embedded assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ make build
 Then run it:
 
 ```sh
-./web server
+./web server -i file:test/.config/server.yml
 ```
 
 > The CLI command is `server`. It is registered in `internal/cmd` and starts the HTTP server using the DI module graph.

--- a/internal/site/site.go
+++ b/internal/site/site.go
@@ -12,6 +12,7 @@ import (
 //go:embed errors/view/*.tmpl
 //go:embed books/view/*.tmpl
 //go:embed books/repository/*.yaml
+//go:embed robots/*.txt
 var filesystem embed.FS
 
 // NewFileSystem returns an `fs.FS` backed by the site's embedded assets.

--- a/test/features/site/site.feature
+++ b/test/features/site/site.feature
@@ -12,6 +12,10 @@ Feature: Web
       | partial | root    |
       | partial | books   |
 
+  Scenario: Visit robots
+    When I visit the robots file
+    Then I should see the robots file
+
   Scenario Outline: Missing section
     When I visit a missing section with layout "<layout>"
     Then I should see the page is missing with layout "<layout>"

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -27,6 +27,21 @@ Then('I should see {string}') do |section|
   expect(html.text).to include(expected[section])
 end
 
+When('I visit the robots file') do
+  opts = {
+    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' },
+    read_timeout: 10, open_timeout: 10
+  }
+
+  @response = Web::V1.http.get_robots(opts)
+end
+
+Then('I should see the robots file') do
+  expect(@response.code).to eq(200)
+  expect(@response.headers[:content_type]).to eq('text/plain; charset=utf-8')
+  expect(@response.body).to include('User-agent: *')
+end
+
 When('I visit a missing section with layout {string}') do |layout|
   headers = { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' }
   layout_headers = {

--- a/test/lib/web/v1/http.rb
+++ b/test/lib/web/v1/http.rb
@@ -46,6 +46,14 @@ module Web
         get('/books', opts)
       end
 
+      # GET the robots.txt file.
+      #
+      # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#get}
+      # @return [Object] the response returned by the underlying HTTP client
+      def get_robots(opts = {})
+        get('/robots.txt', opts)
+      end
+
       # PUT the books page, typically used to request a partial/fragment render.
       #
       # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#put}


### PR DESCRIPTION
## What
- embed the crawler rules text file with the site assets so it is available at runtime
- add acceptance coverage for the static text endpoint through the Ruby test client
- document the required config input for running the built binary locally

## Why
- the static route was registered, but the file was missing from the embedded filesystem and returned 404
- the documented local command failed because the service requires an input config location

## Testing
- go test ./...
- make features
- make lint

AI-assisted-by: [Codex](https://openai.com/codex/)
