### PR TITLE
feat(site): preserve standard navigation fallbacks

### DIFF
--- a/internal/site/root/layout/full.tmpl
+++ b/internal/site/root/layout/full.tmpl
@@ -14,8 +14,8 @@
           <li><strong>Lean Thoughts</strong></li>
         </ul>
         <ul>
-          <li><a hx-put="/" hx-target="#main" hx-push-url="true">Home</a></li>
-          <li><a hx-put="/books" hx-target="#main" hx-push-url="true">Books</a></li>
+          <li><a href="/" hx-put="/" hx-target="#main" hx-push-url="true">Home</a></li>
+          <li><a href="/books" hx-put="/books" hx-target="#main" hx-push-url="true">Books</a></li>
           <li><a href="https://github.com/Lean-Thoughts" target="_blank" rel="noopener noreferrer">Code</a></li>
         </ul>
       </nav>

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 When('I visit {string} with layout {string}') do |section, layout|
+  @layout = layout
   opts = {
     headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0', accept: 'text/html' },
     read_timeout: 10, open_timeout: 10
@@ -25,6 +26,11 @@ Then('I should see {string}') do |section|
   html = Nokogiri::HTML.parse(@response.body)
 
   expect(html.text).to include(expected[section])
+
+  if @layout == 'full'
+    expect(html.at_css('a[href="/"][hx-put="/"]').text).to eq('Home')
+    expect(html.at_css('a[href="/books"][hx-put="/books"]').text).to eq('Books')
+  end
 end
 
 When('I visit the robots file') do


### PR DESCRIPTION
## What
- add normal href values to the Home and Books navigation links while keeping the HTMX PUT behavior
- extend the site feature assertions to verify full-page navigation includes both href fallbacks and matching hx-put attributes

## Why
- navigation should continue to work as regular browser links when HTMX or JavaScript is unavailable
- the acceptance suite now guards the progressive-enhancement contract for the full layout

## Testing
- make features
- make lint
- go test ./...

AI-assisted-by: [Codex](https://openai.com/codex/)
