### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.405.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.21.0
-	github.com/alexfalkowski/go-service/v2 v2.402.0
+	github.com/alexfalkowski/go-service/v2 v2.405.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.21.0 h1:eS1+ixrIvn5C0tl7Q41yICNI5NR+dZ2xGbrQ1lOd59k=
 github.com/alexfalkowski/go-health/v2 v2.21.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.402.0 h1:Jz8PeIB1kMGVqMnHAlNpzsXanYW7sRSkni1LlhY/Hxc=
-github.com/alexfalkowski/go-service/v2 v2.402.0/go.mod h1:aZQ9ZlKIyozDDvt/GYeVrb1MBm1skphSsfr+je1B4Nk=
+github.com/alexfalkowski/go-service/v2 v2.405.0 h1:TCcI1w4B1zQozenAY4h5yntqM4gsmCFOJiej9Z7XSLc=
+github.com/alexfalkowski/go-service/v2 v2.405.0/go.mod h1:aZQ9ZlKIyozDDvt/GYeVrb1MBm1skphSsfr+je1B4Nk=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nonnative (2.15.1)
+    nonnative (2.16.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.405.0
