### PR TITLE
feat(security): add browser response headers

### DIFF
--- a/internal/site/module.go
+++ b/internal/site/module.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/meta"
 	"github.com/alexfalkowski/web/internal/site/robots"
 	"github.com/alexfalkowski/web/internal/site/root"
+	"github.com/alexfalkowski/web/internal/site/security"
 )
 
 // Module for fx.
@@ -16,6 +17,7 @@ var Module = di.Module(
 	errors.Module,
 	robots.Module,
 	root.Module,
+	security.Module,
 	di.Constructor(NewFileSystem),
 	di.Constructor(NewLayout),
 )

--- a/internal/site/security/doc.go
+++ b/internal/site/security/doc.go
@@ -1,0 +1,2 @@
+// Package security provides browser security headers for the site.
+package security

--- a/internal/site/security/headers.go
+++ b/internal/site/security/headers.go
@@ -1,0 +1,33 @@
+package security
+
+import "github.com/alexfalkowski/go-service/v2/net/http"
+
+const contentSecurityPolicy = "default-src 'self'; " +
+	"script-src 'self' https://cdn.jsdelivr.net; " +
+	"style-src 'self' https://cdn.jsdelivr.net; " +
+	"img-src 'self'; " +
+	"connect-src 'self'; " +
+	"font-src 'self'; " +
+	"object-src 'none'; " +
+	"base-uri 'self'; " +
+	"frame-ancestors 'none'"
+
+// NewHandlers returns the HTTP middleware handlers used by the site.
+func NewHandlers() []http.ChainedHandler {
+	return []http.ChainedHandler{Headers{}}
+}
+
+// Headers adds browser security headers to HTTP responses.
+type Headers struct{}
+
+// ServeHTTP implements negroni.Handler.
+func (Headers) ServeHTTP(res http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	header := res.Header()
+	header.Set("Content-Security-Policy", contentSecurityPolicy)
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+	header.Set("X-Frame-Options", "DENY")
+	header.Set("Permissions-Policy", "camera=(), geolocation=(), microphone=()")
+
+	next(res, req)
+}

--- a/internal/site/security/module.go
+++ b/internal/site/security/module.go
@@ -1,0 +1,8 @@
+package security
+
+import "github.com/alexfalkowski/go-service/v2/di"
+
+// Module for fx.
+var Module = di.Module(
+	di.Constructor(NewHandlers),
+)

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+SECURITY_HEADERS = {
+  content_security_policy: "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; " \
+                           "style-src 'self' https://cdn.jsdelivr.net; img-src 'self'; connect-src 'self'; " \
+                           "font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+  x_content_type_options: 'nosniff',
+  referrer_policy: 'strict-origin-when-cross-origin',
+  x_frame_options: 'DENY',
+  permissions_policy: 'camera=(), geolocation=(), microphone=()'
+}.freeze
+
 When('I visit {string} with layout {string}') do |section, layout|
   @layout = layout
   opts = {
@@ -18,6 +28,7 @@ end
 Then('I should see {string}') do |section|
   expect(@response.code).to eq(200)
   expect(@response.headers[:content_type]).to eq('text/html; charset=utf-8')
+  expect_security_headers(@response)
 
   expected = {
     'root' => 'Vince Lombardi',
@@ -45,6 +56,7 @@ end
 Then('I should see the robots file') do
   expect(@response.code).to eq(200)
   expect(@response.headers[:content_type]).to eq('text/plain; charset=utf-8')
+  expect_security_headers(@response)
   expect(@response.body).to include('User-agent: *')
 end
 
@@ -70,9 +82,16 @@ end
 Then('I should see the page is missing with layout {string}') do |layout|
   expect(@response.code).to eq(404)
   expect(@response.headers[:content_type]).to eq('text/html; charset=utf-8')
+  expect_security_headers(@response)
 
   html = Nokogiri::HTML.parse(@response.body)
 
   expect(html.text).to include('Page not found')
   expect(html.text.include?('Copyright')).to eq(layout == 'full')
+end
+
+def expect_security_headers(response)
+  SECURITY_HEADERS.each do |header, value|
+    expect(response.headers[header]).to eq(value)
+  end
 end


### PR DESCRIPTION
## What

- Add site-wide middleware that sets Content-Security-Policy, X-Content-Type-Options, Referrer-Policy, X-Frame-Options, and Permissions-Policy headers.
- Wire the middleware into the site module and assert the headers across page, robots, and not-found feature flows.

## Why

- Harden browser handling for the public website while preserving the jsDelivr assets currently used by the templates.
- Code review found no blocking findings.

## Testing

- `make dep` - passed
- `make lint` - passed
- `make features` - passed
- `make sec` - passed
- `git diff --check HEAD` - passed
