### PR TITLE
feat(security): allow htmx inline styles

### DIFF
--- a/internal/site/security/headers.go
+++ b/internal/site/security/headers.go
@@ -4,8 +4,7 @@ import "github.com/alexfalkowski/go-service/v2/net/http"
 
 const contentSecurityPolicy = "default-src 'self'; " +
 	"script-src 'self' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; " +
-	"style-src 'self' https://cdn.jsdelivr.net; " +
-	"style-src-attr 'unsafe-inline'; " +
+	"style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; " +
 	"img-src 'self'; " +
 	"connect-src 'self' https://cloudflareinsights.com; " +
 	"font-src 'self'; " +

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -2,8 +2,8 @@
 
 SECURITY_HEADERS = {
   content_security_policy: "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net " \
-                           "https://static.cloudflareinsights.com; style-src 'self' https://cdn.jsdelivr.net; " \
-                           "style-src-attr 'unsafe-inline'; img-src 'self'; " \
+                           "https://static.cloudflareinsights.com; style-src 'self' https://cdn.jsdelivr.net " \
+                           "'unsafe-inline'; img-src 'self'; " \
                            "connect-src 'self' https://cloudflareinsights.com; " \
                            "font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
   x_content_type_options: 'nosniff',


### PR DESCRIPTION
## What

- Move the inline style allowance from style-src-attr to style-src.
- Update the acceptance test header expectation to match the browser-enforced CSP.

## Why

- Browser enforcement still reported htmx inline style violations against style-src, so the narrower style-src-attr directive did not cover the runtime behavior.

## Testing

- go test ./... - passed
- gmake build - passed
- gmake lint - passed
- gmake features - passed
- curl -i http://localhost:11000/ - passed, returned style-src with 'unsafe-inline'
