### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.421.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.21.0
-	github.com/alexfalkowski/go-service/v2 v2.419.0
+	github.com/alexfalkowski/go-service/v2 v2.421.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.21.0 h1:eS1+ixrIvn5C0tl7Q41yICNI5NR+dZ2xGbrQ1lOd59k=
 github.com/alexfalkowski/go-health/v2 v2.21.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.419.0 h1:AIVSBg5uyAFSrs7XKVQbtxCCbG4crTmYnZ3QmvwAOpg=
-github.com/alexfalkowski/go-service/v2 v2.419.0/go.mod h1:aZQ9ZlKIyozDDvt/GYeVrb1MBm1skphSsfr+je1B4Nk=
+github.com/alexfalkowski/go-service/v2 v2.421.1 h1:IK+munImM0J+mt8A5sbOFma1Wj13hWnTWkyQ0dG40Hs=
+github.com/alexfalkowski/go-service/v2 v2.421.1/go.mod h1:aZQ9ZlKIyozDDvt/GYeVrb1MBm1skphSsfr+je1B4Nk=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -45,13 +45,13 @@ GEM
     get_process_mem (1.0.0)
       bigdecimal (>= 2.0)
       ffi (~> 1.0)
-    google-protobuf (4.34.1-x86_64-darwin)
+    google-protobuf (4.35.0-x86_64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.34.1-x86_64-linux-gnu)
+    google-protobuf (4.35.0-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos-types (1.22.0)
+    googleapis-common-protos-types (1.23.0)
       google-protobuf (~> 4.26)
     grpc (1.80.0-x86_64-darwin)
       google-protobuf (>= 3.25, < 5.0)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.421.1
