### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.465.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.21.0
-	github.com/alexfalkowski/go-service/v2 v2.463.0
+	github.com/alexfalkowski/go-service/v2 v2.465.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.21.0 h1:eS1+ixrIvn5C0tl7Q41yICNI5NR+dZ2xGbrQ1lOd59k=
 github.com/alexfalkowski/go-health/v2 v2.21.0/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.463.0 h1:7wVQATYG8ZRYbDT8C6ZbiWPO9xXpOfsSfsgNi2VYyxM=
-github.com/alexfalkowski/go-service/v2 v2.463.0/go.mod h1:P4eGzXHIReSZ4Ai05UgyZlzibfWN7WMfEPRSLG6B+m4=
+github.com/alexfalkowski/go-service/v2 v2.465.0 h1:B59y2xkPjOZo5MV7lhKB9tuDBoyOVPozyG4EjYFA6qQ=
+github.com/alexfalkowski/go-service/v2 v2.465.0/go.mod h1:P4eGzXHIReSZ4Ai05UgyZlzibfWN7WMfEPRSLG6B+m4=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.465.0
