### PR TITLE
test(feature): assert rendered page contracts

### DIFF
--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -13,6 +13,38 @@ SECURITY_HEADERS = {
   strict_transport_security: 'max-age=86400'
 }.freeze
 
+EXPECTED_BOOKS = [
+  {
+    title: 'Kanban: Successful Evolutionary Change for Your Technology Business',
+    link: 'https://www.amazon.de/-/en/David-J-Anderson/dp/0984521402'
+  },
+  {
+    title: 'Modern Software Engineering: Doing What Works to Build Better Software Faster',
+    link: 'https://www.amazon.de/-/en/Modern-Software-Engineering-Better-Faster/dp/0137314914'
+  },
+  {
+    title: 'Team Topologies: Organizing Business and Technology Teams for Fast Flow',
+    link: 'https://www.amazon.de/-/en/Team-Topologies-Organizing-Business-Technology/dp/1942788819'
+  }
+].freeze
+
+EXPECTED_PAGE_TEXT = {
+  'root' => 'Vince Lombardi',
+  'books' => 'Margaret Fuller'
+}.freeze
+
+EXPECTED_NAV_LINKS = [
+  { selector: 'a[href="/"][hx-put="/"]', text: 'Home' },
+  { selector: 'a[href="/books"][hx-put="/books"]', text: 'Books' }
+].freeze
+
+FULL_LAYOUT_MARKERS = [
+  /<!doctype/i,
+  /<html\b/i,
+  /<body\b/i,
+  /<nav\b/i
+].freeze
+
 When('I visit {string} with layout {string}') do |section, layout|
   @layout = layout
   opts = {
@@ -33,18 +65,11 @@ Then('I should see {string}') do |section|
   expect(@response.headers[:content_type]).to eq('text/html; charset=utf-8')
   expect_security_headers(@response)
 
-  expected = {
-    'root' => 'Vince Lombardi',
-    'books' => 'Margaret Fuller'
-  }
   html = Nokogiri::HTML.parse(@response.body)
 
-  expect(html.text).to include(expected[section])
-
-  if @layout == 'full'
-    expect(html.at_css('a[href="/"][hx-put="/"]').text).to eq('Home')
-    expect(html.at_css('a[href="/books"][hx-put="/books"]').text).to eq('Books')
-  end
+  expect_page_text(section, html)
+  expect_books(html) if section == 'books'
+  expect_layout(html)
 end
 
 When('I visit the robots file') do
@@ -113,4 +138,45 @@ def expect_security_headers(response)
   SECURITY_HEADERS.each do |header, value|
     expect(response.headers[header]).to eq(value)
   end
+end
+
+def expect_page_text(section, html)
+  expect(html.text).to include(EXPECTED_PAGE_TEXT.fetch(section))
+end
+
+def expect_books(html)
+  expect(book_rows(html)).to eq(EXPECTED_BOOKS)
+end
+
+def book_rows(html)
+  html.css('tbody tr').map { |row| book_row(row) }
+end
+
+def book_row(row)
+  cells = row.css('td')
+  link = cells[1].at_css('a')
+
+  { title: cells[0].text, link: link[:href] }
+end
+
+def expect_layout(html)
+  return expect_full_layout(html) if @layout == 'full'
+
+  expect_partial_layout(html)
+end
+
+def expect_full_layout(html)
+  EXPECTED_NAV_LINKS.each do |link|
+    expect(html.at_css(link.fetch(:selector)).text).to eq(link.fetch(:text))
+  end
+end
+
+def expect_partial_layout(html)
+  FULL_LAYOUT_MARKERS.each { |marker| expect(@response.body).not_to match(marker) }
+
+  EXPECTED_NAV_LINKS.each do |link|
+    expect(html.at_css(link.fetch(:selector))).to be_nil
+  end
+
+  expect(html.text).not_to include('Copyright')
 end


### PR DESCRIPTION
## What

- Assert rendered book titles and links on the books page.
- Assert partial page responses omit the full document shell and navigation chrome.
- Keep page expectation helpers named around behavior.

## Why

- Prevent regressions where the books page stops rendering repository-owned book rows while static copy still passes.
- Prevent HTMX partial routes from accidentally returning full-page markup.

## Testing

- `make ruby-lint` - passed
- `make features` - passed
