### PR TITLE
docs(readme): clarify setup and endpoint guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,37 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexfalkowski/web.svg)](https://pkg.go.dev/github.com/alexfalkowski/web)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 
-# Web
+# 🌐 Web
 
 A small Go service that serves the website at:
 
 - <https://web.lean-thoughts.com/>
 
-The service is built on top of the [`mvc`](https://github.com/alexfalkowski/go-service/tree/master/net/http/mvc) package from `go-service` and ships as a single binary with templates and content embedded.
+The service is built on top of the [`mvc`](https://github.com/alexfalkowski/go-service/tree/master/net/http/mvc) package from `go-service` and ships as a single binary with templates, content, the favicon, and static site assets embedded.
 
-## Background
+## 🧭 Background
 
 This project is an implementation playground for the ideas outlined in:
 
 - <https://alejandrofalkowski.substack.com/p/hyperprogress>
 
-## What it does
+## ✨ What it does
 
 At a high level the service:
 
 - serves the home page (`/`)
 - serves a books page (`/books`)
 - serves `robots.txt` (`/robots.txt`)
-- exposes health and liveness/readiness endpoints (see below)
+- serves the favicon (`/favicon.ico`)
+- renders a custom not-found page for missing routes
+- adds browser security headers to site responses
+- exposes health, liveness/readiness, and metrics endpoints
 
-The HTML templates and the books YAML data are embedded into the binary using `go:embed`.
+The HTML templates, error templates, books YAML data, favicon image, and robots file are embedded into the binary using `go:embed`.
 
-## Architecture overview
+## 🏗️ Architecture overview
 
-### Project layout
+### 🗂️ Project layout
 
 This repo follows the structure described in:
 
@@ -44,7 +47,7 @@ Key directories:
 - `test/`: acceptance/system tests and supporting Ruby test client
 - `bin/` + `Makefile`: build/dev/test automation
 
-### Dependency injection and modules
+### 🧩 Dependency injection and modules
 
 The service is wired with dependency injection using `go-service/v2/di`. The top-level module that assembles the server is:
 
@@ -52,7 +55,7 @@ The service is wired with dependency injection using `go-service/v2/di`. The top
 
 It pulls in configuration, health, and site modules.
 
-### MVC routing and rendering
+### 🛣️ MVC routing and rendering
 
 Routing and rendering are handled using:
 
@@ -60,49 +63,79 @@ Routing and rendering are handled using:
 
 Feature modules (e.g. books/root/robots) register their routes during DI wiring.
 
-### Embedded assets
+### 📦 Embedded assets
 
 The site package embeds:
 
-- templates for layout and pages
+- templates for layout, pages, and not-found errors
 - the books YAML file used to render the books page
+- the favicon PNG
+- `robots.txt`
 
 See:
 
 - `internal/site/site.go`
 
-## Endpoints
+## 🔌 Endpoints
 
-### Pages
+### 📄 Pages
 
 - `GET /` renders the home page
 - `PUT /` renders a partial/fragment version of the home page (used for incremental updates)
 - `GET /books` renders the books page
 - `PUT /books` renders a partial/fragment version of the books page
 - `GET /robots.txt` serves the robots file as a static asset
+- `GET /favicon.ico` serves the browser favicon
+- missing routes render a `404` not-found page
 
-> Note: the `PUT` endpoints exist to support partial rendering patterns (for example HTMX-style incremental updates). The exact response shape depends on the templates/layout configured in the MVC layer.
+> [!NOTE]
+> The `PUT` endpoints exist to support partial rendering patterns, for example HTMX-style incremental updates. The exact response shape depends on the templates/layout configured in the MVC layer.
 
-### Health
+> [!TIP]
+> Use `GET` when checking complete pages in a browser and `PUT` when checking fragment rendering.
+
+### 🫀 Health and observability
 
 The service registers health checks and exposes standard probe endpoints:
 
 - `/healthz` (overall health / online)
 - `/livez` (liveness)
 - `/readyz` (readiness)
+- `/metrics` (Prometheus metrics)
 
 Health timings are configured via the service config under the `health` section.
 
-## Development
+### 🛡️ Response headers
 
-### Prerequisites
+Site responses include browser security headers such as `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`, and `Strict-Transport-Security`.
+
+> [!NOTE]
+> The acceptance suite verifies these headers for the page, robots, favicon, and not-found responses.
+
+## 🧰 Development
+
+### ✅ Prerequisites
 
 Install:
 
 - [Go](https://go.dev/)
 - [Ruby](https://www.ruby-lang.org/en/)
+- Bundler for the Ruby test harness
 
-### Useful Make targets
+Then initialize the shared `bin/` submodule and install dependencies:
+
+```sh
+make submodule
+make dep
+```
+
+> [!IMPORTANT]
+> Run `make submodule` before relying on Make targets. The root `Makefile` includes shared build fragments from `bin/`, so a missing or stale submodule breaks the normal workflow.
+
+> [!WARNING]
+> Some targets require external tools in addition to Go and Ruby. For example, `make dev` uses `air`, Go checks may use `gotestsum`, `golangci-lint`, and `govulncheck`, and security checks may use Trivy.
+
+### 🧾 Useful Make targets
 
 This repo relies on `make` for a consistent developer experience.
 
@@ -127,21 +160,24 @@ make fix-lint
 # Format code
 make format
 
-# Run Go tests
-go test ./...
-
 # Run the repo-defined Go specs wrapper
 make specs
 
 # Run Cucumber acceptance tests
 make features
+
+# Run Cucumber benchmark scenarios
+make benchmarks
 ```
 
-### Running locally
+> [!TIP]
+> `make help` is the best way to discover the current command surface because most project workflows come from the shared `bin/` Make fragments.
+
+### 🚀 Running locally
 
 There are two common ways to run the service:
 
-#### 1) Dev mode
+#### 🔁 1) Dev mode
 
 Use the dev target (recommended while iterating):
 
@@ -149,9 +185,9 @@ Use the dev target (recommended while iterating):
 make dev
 ```
 
-This typically runs the service with a development configuration (see the `Makefile` includes and CI configuration for how it is invoked).
+This runs the service with `test/.config/server.yml`.
 
-#### 2) Build and run the binary
+#### 🧱 2) Build and run the binary
 
 Build a local binary:
 
@@ -162,16 +198,17 @@ make build
 Then run it:
 
 ```sh
-./web server -i file:test/.config/server.yml
+./web server -config file:test/.config/server.yml
 ```
 
-> The CLI command is `server`. It is registered in `internal/cmd` and starts the HTTP server using the DI module graph.
+> [!IMPORTANT]
+> The current config flag is `-config`; `-c` is the short form. The CLI command is `server`, registered in `internal/cmd`, and starts the HTTP server using the DI module graph.
 
-### Example: verifying endpoints
+### 🔎 Example: verifying endpoints
 
 Once the server is running, you can verify key endpoints.
 
-If you started the service with `make dev` (or with `-i file:test/.config/server.yml`),
+If you started the service with `make dev` or with `-config file:test/.config/server.yml`,
 the HTTP server listens on `localhost:11000`.
 
 Pages:
@@ -180,6 +217,7 @@ Pages:
 curl -i http://localhost:11000/
 curl -i http://localhost:11000/books
 curl -i http://localhost:11000/robots.txt
+curl -i http://localhost:11000/favicon.ico
 ```
 
 Partial renders (PUT):
@@ -195,11 +233,19 @@ Health:
 curl -i http://localhost:11000/healthz
 curl -i http://localhost:11000/livez
 curl -i http://localhost:11000/readyz
+curl -i http://localhost:11000/metrics
 ```
 
-> Ports, TLS, and other server settings are controlled by configuration. If your local environment differs, inspect the config used by `make dev` / CI.
+Not found:
 
-## Configuration
+```sh
+curl -i http://localhost:11000/not-a-real-page
+```
+
+> [!CAUTION]
+> Ports, TLS, telemetry, and other server settings come from configuration. Do not treat `test/.config/server.yml` as a production configuration.
+
+## ⚙️ Configuration
 
 The service config model lives in:
 
@@ -207,27 +253,53 @@ The service config model lives in:
 
 It embeds the shared base config from `go-service` and adds a `health` section.
 
-The health section looks conceptually like:
+The canonical local example is:
+
+- `test/.config/server.yml`
+
+The local development config includes:
 
 ```yaml
 health:
-  duration: 5s
-  timeout: 2s
+  duration: 1s
+  timeout: 1s
+transport:
+  http:
+    address: tcp://:11000
 ```
 
-> The exact full configuration file shape depends on the embedded `go-service` base config and the environment in which you run the binary. For canonical examples, check the CI configuration and any config files used by `make dev`.
+> [!NOTE]
+> The full configuration shape also includes shared `go-service` sections such as environment, telemetry, transport, and version metadata.
 
-## Testing
+## 🧪 Testing
 
-### Go
-
-Run all Go tests:
+The primary behavioral checks are the Ruby/Cucumber suites:
 
 ```sh
+make features
+make benchmarks
+```
+
+CI also runs:
+
+```sh
+make lint
+make sec
+make analyse
+make coverage
+```
+
+Go support checks are still available:
+
+```sh
+make specs
 go test ./...
 ```
 
-### Ruby acceptance test client
+> [!NOTE]
+> Treat `make features` and `make benchmarks` as the authoritative product behavior checks. The Go tests support build/tooling confidence but are not the main product signal.
+
+### 💎 Ruby acceptance test client
 
 The Ruby test helper client is in:
 
@@ -236,19 +308,25 @@ The Ruby test helper client is in:
 
 It provides a small wrapper around HTTP calls used by the acceptance tests.
 
-## Style
+## 🎨 Style
 
 Go code generally follows:
 
 - <https://github.com/uber-go/guide/blob/master/style.md>
 
-## Changes / releases
+## 🚢 Changes and releases
 
-See:
+Releases are handled through CI and GoReleaser configuration:
 
-- `CHANGELOG.md`
+- `.circleci/config.yml`
+- `.goreleaser.yml`
 
-## License
+Generated changelog text is part of the GoReleaser release flow.
+
+> [!CAUTION]
+> Release, Docker publishing, deployment, and GitHub PR targets can push to external systems. Use the read-only validation targets unless you intend to publish or update remote state.
+
+## 📜 License
 
 See:
 


### PR DESCRIPTION
## What

- Expanded the project README to cover the actual setup flow, including `make submodule`, dependency installation, and target-specific external tool expectations.
- Updated local run guidance to use the current `-config` / `-c` flags and documented the checked-in local configuration values.
- Added missing endpoint and runtime behavior coverage for favicon, metrics, not-found responses, embedded assets, security headers, and the primary Cucumber validation flow.
- Added emoji-prefixed headings and GitHub admonitions for notes, tips, important setup details, warnings, and cautions.

## Why

- The README had stale or incomplete guidance that could mislead contributors when starting the service, choosing validation commands, or looking for release information.
- Making the command surface and behavioral coverage explicit reduces setup friction and keeps the public project documentation aligned with the repository's Makefile, config, tests, and release wiring.

## Testing

- `make help` - passed
- `make build` - passed
- `./web server --help` - passed
- `git diff --check` - passed
- `rg --glob '!bin/**' --glob '!vendor/**' "CHANGELOG.md|-i file:test|\\[!NOTE\\]|\\[!TIP\\]|\\[!IMPORTANT\\]|\\[!WARNING\\]|\\[!CAUTION\\]" README.md` - passed
- Markdown-specific linting was not run because the repository does not define a markdown lint target.
