### PR TITLE
docs(reliability): record image scan release policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,12 @@ CircleCI is the source of truth for required checks. The main pipeline runs:
 - Site metadata such as the footer year is intentionally computed at startup
   and shared through DI. Do not flag year rollover staleness unless the task is
   explicitly about changing metadata freshness.
+- Docker image scanning is intentionally performed on branch builds before
+  merge by building `test.<platform>` images and running `trivy-image`. The
+  master release path rebuilds and publishes versioned images; do not flag the
+  absence of an additional master image scan as a reliability gap unless the
+  task is explicitly about changing release artifact promotion, base-image
+  pinning, or image scan semantics.
 
 ## Gotchas
 


### PR DESCRIPTION
## What

- Adds repo-specific guidance documenting the Docker image scan policy.
- Clarifies that branch builds scan `test.<platform>` images before merge, while master rebuilds and publishes versioned images.
- Tells future reliability reviews not to flag the absence of an additional master image scan unless release artifact promotion, base-image pinning, or scan semantics are explicitly in scope.

## Why

- Prevents accepted release behavior from being repeatedly surfaced as a reliability gap.
- Keeps future reliability reviews focused on changes the repository actually intends to reconsider.

## Testing

- `make lint` - passed
- No runtime tests were run because this is a repo guidance-only change.
