### PR TITLE
docs(readme): clarify setup and runtime guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ matching skill for the task.
 
 ## First steps
 
-1. Ensure the `bin/` submodule is present:
+1. Ensure the `bin/` submodule is present before using Make targets:
 
 ```sh
-make submodule
+git submodule sync
+git submodule update --init
 ```
 
 2. Install dependencies:
@@ -48,7 +49,7 @@ make help
 If you build locally, start the service with:
 
 ```sh
-./web server
+./web server -config file:test/.config/server.yml
 ```
 
 ## Testing policy
@@ -95,17 +96,17 @@ Embedded assets live in `internal/site/site.go` and include:
 
 - Dev config: `test/.config/server.yml`
 - Dev/test HTTP address: `tcp://:11000`
-- `make dev` runs with `-i file:test/.config/server.yml`
+- `make dev` runs with `-config file:test/.config/server.yml`
 
 The acceptance harness uses `test/nonnative.yml` and starts:
 
 - command: `server`
-- parameters: `-i file:.config/server.yml`
+- parameters: `-config file:.config/server.yml`
 - base URL: `http://localhost:11000`
 
 ## CI truth
 
-CircleCI is the source of truth for required checks. The main pipeline runs:
+CircleCI is the source of truth for required checks. The main service build job runs:
 
 - `make clean && make dep`
 - `make lint`
@@ -114,6 +115,14 @@ CircleCI is the source of truth for required checks. The main pipeline runs:
 - `make benchmarks`
 - `make analyse`
 - `make coverage`
+
+The non-`master` workflow also runs:
+
+- `make platform=amd64 test-docker`
+- `make platform=arm64 test-docker`
+
+The `master` workflow also runs versioning, Docker release/manifest, and deploy
+jobs.
 
 ## Intentional design choices
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A small Go service that serves the website at:
 
 - <https://web.lean-thoughts.com/>
 
-The service is built on top of the [`mvc`](https://github.com/alexfalkowski/go-service/tree/master/net/http/mvc) package from `go-service` and ships as a single binary with templates, content, the favicon, and static site assets embedded.
+The service is built on top of the [`mvc`](https://github.com/alexfalkowski/go-service/tree/master/net/http/mvc) package from `go-service` and ships as a single binary with server-side templates, content, the favicon, and static site assets embedded.
 
 ## 🧭 Background
 
@@ -30,7 +30,7 @@ At a high level the service:
 - adds browser security headers to site responses
 - exposes health, liveness/readiness, and metrics endpoints
 
-The HTML templates, error templates, books YAML data, favicon image, and robots file are embedded into the binary using `go:embed`.
+The HTML templates, error templates, books YAML data, favicon image, and robots file are embedded into the binary using `go:embed`. Full-page browser rendering also loads HTMX and Pico CSS from jsDelivr, with those origins allowed by the response CSP.
 
 ## 🏗️ Architecture overview
 
@@ -105,6 +105,8 @@ The service registers health checks and exposes standard probe endpoints:
 
 Health timings are configured via the service config under the `health` section.
 
+`/healthz` uses the default `go-health/v2` online registration, so it can depend on public connectivity. `/livez` and `/readyz` use noop checks.
+
 ### 🛡️ Response headers
 
 Site responses include browser security headers such as `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`, and `Strict-Transport-Security`.
@@ -122,15 +124,27 @@ Install:
 - [Ruby](https://www.ruby-lang.org/en/)
 - Bundler for the Ruby test harness
 
-Then initialize the shared `bin/` submodule and install dependencies:
+If you are cloning the repo, initialize submodules before relying on Make targets:
 
 ```sh
-make submodule
+git clone --recurse-submodules git@github.com:alexfalkowski/web.git
+```
+
+For an existing checkout where `bin/` may be absent or stale:
+
+```sh
+git submodule sync
+git submodule update --init
+```
+
+Then install dependencies:
+
+```sh
 make dep
 ```
 
 > [!IMPORTANT]
-> Run `make submodule` before relying on Make targets. The root `Makefile` includes shared build fragments from `bin/`, so a missing or stale submodule breaks the normal workflow.
+> The root `Makefile` includes shared build fragments from `bin/`, so a missing submodule can prevent `make` from parsing at all. Once `bin/` is present, `make submodule` can refresh it through the normal repo target.
 
 > [!WARNING]
 > Some targets require external tools in addition to Go and Ruby. For example, `make dev` uses `air`, Go checks may use `gotestsum`, `golangci-lint`, and `govulncheck`, and security checks may use Trivy.
@@ -280,7 +294,7 @@ make features
 make benchmarks
 ```
 
-CI also runs:
+The main CircleCI service build also runs:
 
 ```sh
 make lint
@@ -288,6 +302,15 @@ make sec
 make analyse
 make coverage
 ```
+
+The full CircleCI workflow additionally runs Docker image checks on non-`master` branches:
+
+```sh
+make platform=amd64 test-docker
+make platform=arm64 test-docker
+```
+
+On `master`, CircleCI also runs versioning, Docker release/manifest, and deploy jobs.
 
 Go support checks are still available:
 

--- a/internal/cmd/module.go
+++ b/internal/cmd/module.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site"
 )
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	module.Server,
 	config.Module,

--- a/internal/config/module.go
+++ b/internal/config/module.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexfalkowski/go-service/v2/di"
 )
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Constructor(config.NewConfig[Config]),
 	di.Decorate(decorateConfig),

--- a/internal/health/doc.go
+++ b/internal/health/doc.go
@@ -3,9 +3,13 @@
 // This package registers health checks and HTTP observers against the service's
 // server, enabling standard Kubernetes-style probes:
 //
-//   - /healthz   overall health (online)
+//   - /healthz   overall health (default online connectivity check)
 //   - /livez     liveness (noop)
 //   - /readyz    readiness (noop)
+//
+// The /healthz observer is backed by go-health/v2's default online
+// registration, so restricted public connectivity can affect the overall health
+// response. The liveness and readiness observers use noop registrations.
 //
 // The configuration for probe timing is provided via Config and is expected to
 // be loaded from the service's root configuration.

--- a/internal/health/module.go
+++ b/internal/health/module.go
@@ -2,7 +2,7 @@ package health
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Register(register),
 	di.Register(httpHealthObserver),

--- a/internal/site/books/module.go
+++ b/internal/site/books/module.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/books/route"
 )
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	repository.Module,
 	route.Module,

--- a/internal/site/books/repository/module.go
+++ b/internal/site/books/repository/module.go
@@ -2,7 +2,7 @@ package repository
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Constructor(NewRepository),
 )

--- a/internal/site/books/route/module.go
+++ b/internal/site/books/route/module.go
@@ -2,7 +2,7 @@ package route
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Register(Register),
 )

--- a/internal/site/books/route/route.go
+++ b/internal/site/books/route/route.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/books/view"
 )
 
-// Register root.
+// Register installs the books routes.
 func Register(repo repository.Repository) {
 	view, partialView := view.NewBooks()
 

--- a/internal/site/errors/module.go
+++ b/internal/site/errors/module.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/errors/route"
 )
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	route.Module,
 )

--- a/internal/site/errors/route/module.go
+++ b/internal/site/errors/route/module.go
@@ -2,7 +2,7 @@ package route
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Register(Register),
 )

--- a/internal/site/favicon/module.go
+++ b/internal/site/favicon/module.go
@@ -2,7 +2,7 @@ package favicon
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Register(Register),
 )

--- a/internal/site/meta/module.go
+++ b/internal/site/meta/module.go
@@ -2,7 +2,7 @@ package meta
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Constructor(NewYear),
 	di.Constructor(NewInfo),

--- a/internal/site/module.go
+++ b/internal/site/module.go
@@ -11,7 +11,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/security"
 )
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	meta.Module,
 	books.Module,

--- a/internal/site/robots/module.go
+++ b/internal/site/robots/module.go
@@ -2,7 +2,7 @@ package robots
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Register(Register),
 )

--- a/internal/site/root/module.go
+++ b/internal/site/root/module.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/root/route"
 )
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	route.Module,
 )

--- a/internal/site/root/route/module.go
+++ b/internal/site/root/route/module.go
@@ -2,7 +2,7 @@ package route
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Register(Register),
 )

--- a/internal/site/root/route/route.go
+++ b/internal/site/root/route/route.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/root/view"
 )
 
-// Register root.
+// Register installs the root routes.
 func Register(info *meta.Info) {
 	view, partialView := view.NewRoot()
 

--- a/internal/site/security/module.go
+++ b/internal/site/security/module.go
@@ -2,7 +2,7 @@ package security
 
 import "github.com/alexfalkowski/go-service/v2/di"
 
-// Module for fx.
+// Module wires this package into the dependency graph.
 var Module = di.Module(
 	di.Constructor(NewHandlers),
 )

--- a/test/features/site/benchmark.feature
+++ b/test/features/site/benchmark.feature
@@ -1,7 +1,7 @@
 @benchmark
 Feature: Benchmark Web
-  Make sure these endpoints perform at their best.
+  Make sure the root page performs at its best.
 
-  Scenario: Visit site in a good time frame and memory.
+  Scenario: Visit the root page in a good time frame and memory.
     When I visit the site which performs in 15 ms
     And the process 'server' should consume less than '70mb' of memory

--- a/test/lib/web/v1/http.rb
+++ b/test/lib/web/v1/http.rb
@@ -11,7 +11,7 @@ module Web
     # and forwards an optional options hash to the base client.
     #
     # @example Fetch the root page
-    #   client = Web::V1::HTTP.new("http://localhost:8080")
+    #   client = Web::V1::HTTP.new("http://localhost:11000")
     #   response = client.get_root
     #
     # @example Request the partial version of a page (PUT)


### PR DESCRIPTION
## What

- Clarified fresh-clone and existing-checkout bootstrap instructions so submodules are initialized before Make targets are used.
- Updated local runtime, acceptance harness, CI workflow, health-check, and browser asset documentation to match the current repository behavior.
- Corrected stale Go exported comments, the Ruby HTTP client example port, and benchmark feature wording.

## Why

- The previous docs could block new contributors on missing `bin/` make fragments, point maintainers at stale config flags, and understate CI and operational dependencies.
- Aligning comments and examples with the current code reduces generated-doc and acceptance-harness confusion without changing runtime behavior.

## Testing

- `make lint` - passed
- `make benchmarks` - passed
- `rg -n "Module for fx|Register root\\.|-i file|localhost:8080|these endpoints" README.md AGENTS.md internal test --glob '!bin/**'` - passed; no stale phrases found
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
