### PR TITLE
docs(readme): clarify ci and acceptance workflow side effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,11 +115,16 @@ CircleCI is the source of truth for required checks. The main service build job 
 - `make benchmarks`
 - `make analyse`
 - `make coverage`
+- `make codecov-upload`
+
+`make codecov-upload` is CI upload behavior, not a read-only local validation
+step.
 
 The non-`master` workflow also runs:
 
 - `make platform=amd64 test-docker`
 - `make platform=arm64 test-docker`
+- `make sync push`
 
 The `master` workflow also runs versioning, Docker release/manifest, and deploy
 jobs.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Health timings are configured via the service config under the `health` section.
 
 Site responses include browser security headers such as `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`, and `Strict-Transport-Security`.
 
+The CSP intentionally permits jsDelivr for HTMX and Pico CSS, plus Cloudflare Insights script and beacon origins (`static.cloudflareinsights.com` and `cloudflareinsights.com`) for production browser analytics.
+
 > [!NOTE]
 > The acceptance suite verifies these headers for the page, robots, favicon, and not-found responses.
 
@@ -294,6 +296,12 @@ make features
 make benchmarks
 ```
 
+These targets run the acceptance harness from `test/`. Nonnative loads
+`test/nonnative.yml`, starts `../web server -config file:.config/server.yml` on
+`localhost:11000`, and writes Nonnative, server, and Cucumber output under
+`test/reports/`. Stop any local service already using `11000` before running the
+acceptance suites.
+
 The main CircleCI service build also runs:
 
 ```sh
@@ -301,13 +309,19 @@ make lint
 make sec
 make analyse
 make coverage
+make codecov-upload
 ```
 
-The full CircleCI workflow additionally runs Docker image checks on non-`master` branches:
+`make codecov-upload` is CI upload behavior, not a read-only local validation
+step.
+
+The full CircleCI workflow additionally runs Docker image checks and the
+submodule sync/push job on non-`master` branches:
 
 ```sh
 make platform=amd64 test-docker
 make platform=arm64 test-docker
+make sync push
 ```
 
 On `master`, CircleCI also runs versioning, Docker release/manifest, and deploy jobs.


### PR DESCRIPTION
## What

- Document the Cloudflare Insights origins allowed by the response CSP alongside the existing jsDelivr asset note.
- Add local acceptance harness details for `make features` and `make benchmarks`, including the Nonnative config, managed server command, port ownership, and report output.
- Update CI workflow notes with the Codecov upload step and the non-`master` `make sync push` job.

## Why

- Maintainers need the docs to identify remote-writing CI behavior, external upload behavior, and local acceptance-runtime ownership without reverse-engineering CircleCI or Nonnative config.
- The CSP note gives reviewers and operators the reason for third-party analytics origins that are enforced by the acceptance suite.

## Testing

- `make lint` - passed
- Behavioral suites were not run because this changes documentation only.
