### PR TITLE
docs(readme): clarify service contracts

### DIFF
--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -9,6 +9,9 @@
 //
 // # Public API
 //
-// The only public type in this package is Config, which represents the root of
-// the service configuration file.
+// The public surface is:
+//   - Config, which represents the root of the service configuration file.
+//   - Module, which loads Config through the shared go-service configuration
+//     constructor and exposes the embedded base config plus health config to the
+//     DI graph.
 package config

--- a/internal/health/config.go
+++ b/internal/health/config.go
@@ -8,7 +8,7 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // parsed as Go durations.
 //
 // Duration controls how often health registrations are evaluated/updated.
-// Timeout is reserved for probe/check timeout configuration.
+// Timeout controls the default online health check timeout.
 type Config struct {
 	// Duration is the health check evaluation interval (for example "5s").
 	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty" validate:"gt=0"`

--- a/internal/site/books/controller/controller.go
+++ b/internal/site/books/controller/controller.go
@@ -7,7 +7,8 @@ import (
 	"github.com/alexfalkowski/web/internal/site/books/repository"
 )
 
-// NewBooks controller.
+// NewBooks returns an MVC controller that loads the books model from the
+// repository and renders it with the provided view.
 func NewBooks(repo repository.Repository, view *mvc.View) mvc.Controller[model.Books] {
 	return func(_ context.Context) (*mvc.View, *model.Books, error) {
 		model := repo.GetBooks()

--- a/internal/site/books/model/model.go
+++ b/internal/site/books/model/model.go
@@ -3,13 +3,13 @@ package model
 import "github.com/alexfalkowski/web/internal/site/meta"
 
 type (
-	// Books for site.
+	// Books is the view model rendered by the books page.
 	Books struct {
 		Info  *meta.Info `yaml:"-"`
 		Books []*Book    `yaml:"books,omitempty"`
 	}
 
-	// Book for site.
+	// Book describes one book link loaded from the embedded YAML content.
 	Book struct {
 		Title string `yaml:"title,omitempty"`
 		Link  string `yaml:"link,omitempty"`

--- a/internal/site/books/repository/books.yaml
+++ b/internal/site/books/repository/books.yaml
@@ -1,3 +1,4 @@
+# Books are rendered alphabetically by title; file order is not display order.
 books:
   -
     title: "Kanban: Successful Evolutionary Change for Your Technology Business"

--- a/internal/site/books/repository/repository.go
+++ b/internal/site/books/repository/repository.go
@@ -19,6 +19,9 @@ import (
 // meta information) suitable for rendering by the MVC layer.
 type Repository interface {
 	// GetBooks returns the books view model loaded from the underlying storage.
+	//
+	// The default filesystem-backed implementation panics if the embedded books
+	// YAML file cannot be read or decoded.
 	GetBooks() *model.Books
 }
 

--- a/internal/site/books/route/route.go
+++ b/internal/site/books/route/route.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/books/view"
 )
 
-// Register installs the books routes.
+// Register installs the GET and PUT /books routes on the global MVC router.
 func Register(repo repository.Repository) {
 	view, partialView := view.NewBooks()
 

--- a/internal/site/books/view/view.go
+++ b/internal/site/books/view/view.go
@@ -2,7 +2,8 @@ package view
 
 import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
-// NewBooks view.
+// NewBooks returns the full-page and partial views bound to the books
+// templates.
 func NewBooks() (*mvc.View, *mvc.View) {
 	return mvc.NewViewPair("books/view/books.tmpl")
 }

--- a/internal/site/errors/controller/controller.go
+++ b/internal/site/errors/controller/controller.go
@@ -9,7 +9,8 @@ import (
 	site "github.com/alexfalkowski/web/internal/site/meta"
 )
 
-// NewNotFound controller.
+// NewNotFound returns an MVC not-found controller that renders the full page for
+// normal requests and the partial fragment for PUT requests.
 func NewNotFound(info *site.Info, view *mvc.View, partialView *mvc.View) mvc.NotFoundController[model.NotFound] {
 	return func(ctx context.Context) (*mvc.View, *model.NotFound) {
 		notFound := &model.NotFound{Info: info}

--- a/internal/site/errors/model/doc.go
+++ b/internal/site/errors/model/doc.go
@@ -1,2 +1,5 @@
 // Package model defines view models for the error feature.
+//
+// The types in this package are rendered by the not-found templates and carry
+// shared site metadata into error responses.
 package model

--- a/internal/site/errors/model/model.go
+++ b/internal/site/errors/model/model.go
@@ -2,7 +2,7 @@ package model
 
 import "github.com/alexfalkowski/web/internal/site/meta"
 
-// NotFound model.
+// NotFound is the view model rendered by the not-found page and fragment.
 type NotFound struct {
 	Info *meta.Info
 }

--- a/internal/site/errors/route/doc.go
+++ b/internal/site/errors/route/doc.go
@@ -1,2 +1,13 @@
-// Package route registers routes for the error feature.
+// Package route registers the global not-found handler for the error feature.
+//
+// This package installs the MVC not-found controller used when no registered
+// route matches a request. The controller renders either the full not-found page
+// or the partial not-found fragment, matching the same full/partial rendering
+// behavior used by the normal site routes.
+//
+// # Public API
+//
+// Register installs the global not-found handler on the MVC router. It is
+// typically invoked via dependency injection (see this package's Module) rather
+// than being called directly by application code.
 package route

--- a/internal/site/errors/route/route.go
+++ b/internal/site/errors/route/route.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/meta"
 )
 
-// Register not found.
+// Register installs the global not-found handler on the MVC router.
 func Register(info *meta.Info) {
 	view, partialView := view.NewNotFound()
 

--- a/internal/site/errors/view/doc.go
+++ b/internal/site/errors/view/doc.go
@@ -1,2 +1,5 @@
 // Package view defines MVC views for the error feature.
+//
+// The views in this package bind the not-found templates to MVC view instances
+// used by the global not-found controller.
 package view

--- a/internal/site/errors/view/view.go
+++ b/internal/site/errors/view/view.go
@@ -2,7 +2,8 @@ package view
 
 import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
-// NewNotFound view.
+// NewNotFound returns the full-page and partial views bound to the not-found
+// templates.
 func NewNotFound() (*mvc.View, *mvc.View) {
 	return mvc.NewViewPair("errors/view/not_found.tmpl")
 }

--- a/internal/site/favicon/doc.go
+++ b/internal/site/favicon/doc.go
@@ -1,2 +1,13 @@
 // Package favicon registers the site's browser icon endpoint.
+//
+// The favicon image is bundled with the binary through the site embedded
+// filesystem and exposed as a static file at:
+//
+//   - GET /favicon.ico
+//
+// # Public API
+//
+// Register installs the static route for /favicon.ico on the global MVC router.
+// It is typically invoked via dependency injection (see this package's Module)
+// rather than being called directly by application code.
 package favicon

--- a/internal/site/favicon/favicon.go
+++ b/internal/site/favicon/favicon.go
@@ -2,7 +2,7 @@ package favicon
 
 import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
-// Register favicon.
+// Register installs the static favicon route on the global MVC router.
 func Register() {
 	mvc.StaticFile("/favicon.ico", "favicon/favicon.png")
 }

--- a/internal/site/robots/robots.go
+++ b/internal/site/robots/robots.go
@@ -2,7 +2,7 @@ package robots
 
 import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
-// Register robots.
+// Register installs the static robots.txt route on the global MVC router.
 func Register() {
 	mvc.StaticFile("/robots.txt", "robots/robots.txt")
 }

--- a/internal/site/root/controller/controller.go
+++ b/internal/site/root/controller/controller.go
@@ -7,7 +7,8 @@ import (
 	"github.com/alexfalkowski/web/internal/site/root/model"
 )
 
-// NewRoot controller.
+// NewRoot returns an MVC controller that renders the root model with shared site
+// metadata.
 func NewRoot(info *meta.Info, view *mvc.View) mvc.Controller[model.Root] {
 	return func(_ context.Context) (*mvc.View, *model.Root, error) {
 		root := &model.Root{Info: info}

--- a/internal/site/root/model/model.go
+++ b/internal/site/root/model/model.go
@@ -2,7 +2,7 @@ package model
 
 import "github.com/alexfalkowski/web/internal/site/meta"
 
-// Root model.
+// Root is the view model rendered by the home page and fragment.
 type Root struct {
 	Info *meta.Info
 }

--- a/internal/site/root/route/route.go
+++ b/internal/site/root/route/route.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/root/view"
 )
 
-// Register installs the root routes.
+// Register installs the GET and PUT root routes on the global MVC router.
 func Register(info *meta.Info) {
 	view, partialView := view.NewRoot()
 

--- a/internal/site/root/view/view.go
+++ b/internal/site/root/view/view.go
@@ -2,7 +2,7 @@ package view
 
 import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
-// NewRoot view.
+// NewRoot returns the full-page and partial views bound to the root templates.
 func NewRoot() (*mvc.View, *mvc.View) {
 	return mvc.NewViewPair("root/view/root.tmpl")
 }

--- a/internal/site/security/doc.go
+++ b/internal/site/security/doc.go
@@ -1,2 +1,8 @@
 // Package security provides browser security headers for the site.
+//
+// The exported middleware sets the site's Content-Security-Policy,
+// X-Content-Type-Options, Referrer-Policy, X-Frame-Options, Permissions-Policy,
+// and Strict-Transport-Security headers. The CSP allowlist is coupled to the
+// external assets used by the full-page templates, including jsDelivr-hosted
+// HTMX/Pico CSS assets and Cloudflare Insights browser analytics endpoints.
 package security

--- a/internal/site/security/headers.go
+++ b/internal/site/security/headers.go
@@ -12,12 +12,14 @@ const contentSecurityPolicy = "default-src 'self'; " +
 	"base-uri 'self'; " +
 	"frame-ancestors 'none'"
 
-// NewHandlers returns the HTTP middleware handlers used by the site.
+// NewHandlers returns the HTTP middleware handlers that enforce the site's
+// browser security header policy.
 func NewHandlers() []http.ChainedHandler {
 	return []http.ChainedHandler{Headers{}}
 }
 
-// Headers adds browser security headers to HTTP responses.
+// Headers adds the site's CSP, content type, referrer, frame, permissions, and
+// HSTS headers to HTTP responses before passing control to the next handler.
 type Headers struct{}
 
 // ServeHTTP implements negroni.Handler.

--- a/test/features/site/site.feature
+++ b/test/features/site/site.feature
@@ -1,7 +1,9 @@
 Feature: Web
   Web is a website for lean-thoughts.com
+  Site rendering scenarios assert successful HTML responses, security headers,
+  expected page content, and the requested full or partial layout.
 
-  Scenario Outline: Visit sections
+  Scenario Outline: Render sections with expected layout and headers
     When I visit "<section>" with layout "<layout>"
     Then I should see "<section>"
 


### PR DESCRIPTION
## What

- Clarify GoDoc for site wiring, route/view/controller/model surfaces, health timeout behavior, security middleware headers, favicon routing, and books repository failure behavior.
- Document that embedded books content is rendered by title rather than file order.
- Update the site feature description to state the acceptance contract around successful responses, security headers, page content, and full/partial layouts.

## Why

- Reduces maintenance risk for future route, asset, security header, and content changes by putting non-obvious contracts next to the surfaces maintainers edit.
- Keeps the acceptance feature readable as an executable specification for the behavior its step definitions already verify.

## Testing

- `make lint` - passed
- `make features` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
