### PR TITLE
docs(readme): clarify setup and configuration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ The CSP intentionally permits jsDelivr for HTMX and Pico CSS, plus Cloudflare In
 
 Install:
 
-- [Go](https://go.dev/)
+- [Go](https://go.dev/) (see `go.mod`; check locally with `go version`)
 - [Ruby](https://www.ruby-lang.org/en/)
 - Bundler for the Ruby test harness
 
 If you are cloning the repo, initialize submodules before relying on Make targets:
 
 ```sh
-git clone --recurse-submodules git@github.com:alexfalkowski/web.git
+git clone --recurse-submodules https://github.com/alexfalkowski/web.git
 ```
 
 For an existing checkout where `bin/` may be absent or stale:
@@ -273,7 +273,8 @@ The canonical local example is:
 
 - `test/.config/server.yml`
 
-The local development config includes:
+The local development config in `test/.config/server.yml` includes this
+first-use excerpt:
 
 ```yaml
 health:
@@ -284,8 +285,13 @@ transport:
     address: tcp://:11000
 ```
 
+The service-specific `health` section is required. `health.duration` must be a
+positive Go duration and controls how often health registrations are evaluated;
+`health.timeout` may be zero or greater and controls the online health check
+timeout.
+
 > [!NOTE]
-> The full configuration shape also includes shared `go-service` sections such as environment, telemetry, transport, and version metadata.
+> The full local config also sets the environment, UUID generation, tint logging, Prometheus metrics, an OTLP tracer endpoint, HTTP limiter tokens/interval, and HTTP timeout. The wider configuration shape comes from shared `go-service` sections such as environment, telemetry, transport, and version metadata.
 
 ## 🧪 Testing
 
@@ -301,6 +307,15 @@ These targets run the acceptance harness from `test/`. Nonnative loads
 `localhost:11000`, and writes Nonnative, server, and Cucumber output under
 `test/reports/`. Stop any local service already using `11000` before running the
 acceptance suites.
+
+To run a narrower acceptance scope while iterating, pass feature paths relative
+to `test/`:
+
+```sh
+make features feature=features/site/site.feature
+make features feature=features/health/observability.feature
+make benchmarks feature=features/site/benchmark.feature
+```
 
 The main CircleCI service build also runs:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,10 @@ import (
 //
 // The struct tags allow it to be loaded from YAML, JSON, or TOML.
 type Config struct {
-	Health         *health.Config `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
+	// Health is the required service-specific health probe configuration.
+	Health *health.Config `yaml:"health,omitempty" json:"health,omitempty" toml:"health,omitempty" validate:"required"`
+
+	// Config is the required shared go-service base configuration.
 	*config.Config `yaml:",inline" json:",inline" toml:",inline" validate:"required"`
 }
 

--- a/internal/health/config.go
+++ b/internal/health/config.go
@@ -10,9 +10,11 @@ import "github.com/alexfalkowski/go-service/v2/time"
 // Duration controls how often health registrations are evaluated/updated.
 // Timeout controls the default online health check timeout.
 type Config struct {
-	// Duration is the health check evaluation interval (for example "5s").
+	// Duration is the health check evaluation interval and must be greater than
+	// zero (for example "5s").
 	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty" toml:"duration,omitempty" validate:"gt=0"`
 
-	// Timeout is the maximum time allowed for a health check/probe (for example "2s").
+	// Timeout is the maximum time allowed for a health check/probe and may be zero
+	// or greater (for example "2s").
 	Timeout time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" toml:"timeout,omitempty" validate:"gte=0"`
 }


### PR DESCRIPTION
## What

- Clarifies the project prerequisites by pointing Go users to `go.mod` and `go version`.
- Switches the clone example to HTTPS so first-time setup does not require GitHub SSH configuration.
- Marks the local config YAML as a first-use excerpt and documents the required health section and duration constraints.
- Adds narrower Cucumber feature and benchmark command examples for focused local iteration.
- Tightens exported config comments so required health and base config contracts are visible outside struct tags.

## Why

- Reduces first-use setup friction and makes the README clearer about where version and configuration truth lives.
- Helps contributors avoid copying an incomplete local config sample as a full production-ready configuration.
- Makes the health configuration contract discoverable in both the README and Go package documentation.

## Testing

- `make lint` - passed
- `git diff --check` - passed
