### PR TITLE
test(feature): centralize harness request options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp
 dist
 .source-key
 ISSUES.md
+FEATURES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,17 @@ jobs.
 - Site metadata such as the footer year is intentionally computed at startup
   and shared through DI. Do not flag year rollover staleness unless the task is
   explicitly about changing metadata freshness.
+- This repository consumes shared Make targets from the `bin/` submodule. If a
+  one-command local CI preflight target is needed, it should be added to the
+  shared `bin` Make fragments rather than as a service-local target here. Do not
+  flag the lack of a root `verify`/`ci-checks` target as a feature gap by
+  default.
+- The Ruby code under `test/` is a local feature-test harness, not production
+  service code. Fixed localhost endpoints in `test/lib/**`, `test/nonnative.yml`,
+  and related feature helpers are intentional local harness assumptions unless
+  there is concrete evidence of current workflow breakage. Do not flag the lack
+  of environment-configurable HTTP or observability endpoints as a feature gap by
+  default.
 
 ## Gotchas
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak

--- a/test/features/step_definitions/health/observability_steps.rb
+++ b/test/features/step_definitions/health/observability_steps.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 When('the system requests the {string} with HTTP') do |name|
-  opts = {
-    headers: { request_id: SecureRandom.uuid },
-    read_timeout: 10, open_timeout: 10
-  }
+  opts = Web.http_options
 
   @response = Nonnative.observability.send(name, opts)
 end

--- a/test/features/step_definitions/site/benchmark_steps.rb
+++ b/test/features/step_definitions/site/benchmark_steps.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 When('I visit the site which performs in {int} ms') do |time|
-  opts = {
+  opts = Web.http_options(
     headers: {
-      request_id: SecureRandom.uuid, user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
+      user_agent: 'Status-ruby-client/1.0 HTTP/1.0',
       content_type: :json, accept: :json
-    },
-    read_timeout: 10, open_timeout: 10
-  }
+    }
+  )
 
   expect { Web::V1.http.get_root(opts) }.to perform_under(time).ms
 end

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -47,10 +47,7 @@ FULL_LAYOUT_MARKERS = [
 
 When('I visit {string} with layout {string}') do |section, layout|
   @layout = layout
-  opts = {
-    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0', accept: 'text/html' },
-    read_timeout: 10, open_timeout: 10
-  }
+  opts = Web.http_options(headers: { user_agent: 'Web-client/1.0 HTTP/1.0', accept: 'text/html' })
   methods = {
     'full' => 'get',
     'partial' => 'put'
@@ -73,19 +70,13 @@ Then('I should see {string}') do |section|
 end
 
 When('I visit the robots file') do
-  opts = {
-    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' },
-    read_timeout: 10, open_timeout: 10
-  }
+  opts = Web.http_options(headers: { user_agent: 'Web-client/1.0 HTTP/1.0' })
 
   @response = Web::V1.http.get_robots(opts)
 end
 
 When('I visit the favicon') do
-  opts = {
-    headers: { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' },
-    read_timeout: 10, open_timeout: 10
-  }
+  opts = Web.http_options(headers: { user_agent: 'Web-client/1.0 HTTP/1.0' })
 
   @response = Web::V1.http.get_favicon(opts)
 end
@@ -105,15 +96,12 @@ Then('I should see the favicon') do
 end
 
 When('I visit a missing section with layout {string}') do |layout|
-  headers = { request_id: SecureRandom.uuid, user_agent: 'Web-client/1.0 HTTP/1.0' }
+  headers = { user_agent: 'Web-client/1.0 HTTP/1.0' }
   layout_headers = {
     'full' => { accept: 'text/html' },
     'partial' => { hx_request: 'true' }
   }
-  opts = {
-    headers: headers.merge(layout_headers[layout]),
-    read_timeout: 10, open_timeout: 10
-  }
+  opts = Web.http_options(headers: headers.merge(layout_headers[layout]))
   methods = {
     'full' => 'get',
     'partial' => 'put'

--- a/test/lib/web.rb
+++ b/test/lib/web.rb
@@ -15,6 +15,27 @@ module Web
 
   require 'web/v1/http'
 
+  class << self
+    ##
+    # Returns bounded per-call options for HTTP feature-harness requests.
+    #
+    # Each call includes a generated `request_id` header. Caller-provided
+    # headers are merged afterward, so scenarios can override that value or add
+    # transport-specific headers such as content type and user agent.
+    #
+    # @param headers [Hash] HTTP headers merged after the generated request id
+    # @param read_timeout [Integer] read timeout in seconds
+    # @param open_timeout [Integer] connection open timeout in seconds
+    # @return [Hash] options compatible with `Nonnative::HTTPClient` calls
+    def http_options(headers: {}, read_timeout: 10, open_timeout: 10)
+      {
+        headers: { request_id: SecureRandom.uuid }.merge(headers),
+        read_timeout:,
+        open_timeout:
+      }
+    end
+  end
+
   # Versioned namespace for the web service test client.
   #
   # The V1 namespace provides a stable entrypoint for interacting with the


### PR DESCRIPTION
## What

- Add repo guidance that keeps shared-bin CI preflight ownership and local harness endpoint assumptions from resurfacing as gaps.
- Ignore the temporary feature-gap ledger file and expose help output from the Ruby harness Makefile.
- Centralize per-call HTTP options behind `Web.http_options` and use it from site, benchmark, and observability steps.

## Why

- Reviewers need durable repo-local guidance for accepted boundaries so future gap passes focus on actionable service work.
- The Ruby harness command surface should be discoverable from `test/` in the same way as other shared Make targets.
- Shared HTTP request options reduce repeated setup while preserving generated request IDs, timeouts, and caller-specific headers.

## Testing

- `make -C test help` - passed
- `make lint` - passed
- `make features` - passed, covering 12 scenarios and 24 steps
- `make benchmarks` - passed, covering 1 scenario and 2 steps
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
