### PR TITLE
build(ci): tighten project workflow defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,23 +14,23 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - web-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - web-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - web-go-cache-
       - restore_cache:
           name: restore ruby cache
           keys:
-            - web-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+            - web-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
             - web-ruby-cache-
       - run: make clean
       - run: make dep
       - save_cache:
           name: save go cache
-          key: web-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+          key: web-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
           paths:
             - ~/go/pkg/mod
       - save_cache:
           name: save ruby cache
-          key: web-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}-{{ checksum ".source-key" }}
+          key: web-ruby-cache-{{ checksum "test/Gemfile.lock" }}-{{ checksum "~/.ruby-version" }}
           paths:
             - test/vendor
       - restore_cache:
@@ -90,7 +90,7 @@ jobs:
       - restore_cache:
           name: restore go cache
           keys:
-            - web-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - web-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - web-go-cache-
       - restore_cache:
           name: restore go build cache

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 .source-key
 ISSUES.md
 FEATURES.md
+PROJECTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,21 @@ jobs.
   shared `bin` Make fragments rather than as a service-local target here. Do not
   flag the lack of a root `verify`/`ci-checks` target as a feature gap by
   default.
+- CircleCI's `version` job runs the external `package` command from the
+  `alexfalkowski/release` image. That release image owns GoReleaser config
+  validation before release packaging. Do not flag the absence of a separate
+  repository-local GoReleaser config validation job as a project gap by default
+  unless there is concrete evidence that the release image no longer validates
+  `.goreleaser.yml`, or that this repository has explicitly decided to own a
+  pre-release GoReleaser check locally.
+- The Ruby code under `test/` is a local feature-test harness, not production
+  service code. Ruby runtime selection for this harness is owned by the shared
+  repository tooling and CI images. Do not flag the absence of a
+  repository-local `.ruby-version`, `.tool-versions`, `mise.toml`, or Gemfile
+  `ruby` directive as a project gap by default unless there is concrete evidence
+  that the current workflow no longer supplies the expected runtime, or that this
+  repository has explicitly decided to own Ruby version selection locally for the
+  test harness.
 - The Ruby code under `test/` is a local feature-test harness, not production
   service code. Fixed localhost endpoints in `test/lib/**`, `test/nonnative.yml`,
   and related feature helpers are intentional local harness assumptions unless


### PR DESCRIPTION
## What

- Narrow CircleCI dependency cache keys so Go module and Ruby bundle caches no longer depend on the broad repository source hash.
- Keep source-sensitive invalidation for Go build and lint caches.
- Ignore project-gap audit output and document reviewer guardrails for GoReleaser validation and Ruby runtime ownership.

## Why

- Reduces unnecessary dependency cache churn from unrelated source, docs, config, or fixture edits.
- Keeps future project-gap reviews focused on repository-owned workflow gaps instead of release-image or runtime-image responsibilities.

## Testing

- `circleci config validate .circleci/config.yml` - passed
- `git diff --check` - passed
- `zsh -lic 'make lint'` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
