### PR TITLE
feat(meta): add page-specific document details

### DIFF
--- a/internal/site/books/model/model.go
+++ b/internal/site/books/model/model.go
@@ -6,6 +6,7 @@ type (
 	// Books is the view model rendered by the books page.
 	Books struct {
 		Info  *meta.Info `yaml:"-"`
+		Page  meta.Page  `yaml:"-"`
 		Books []*Book    `yaml:"books,omitempty"`
 	}
 

--- a/internal/site/books/repository/repository.go
+++ b/internal/site/books/repository/repository.go
@@ -67,6 +67,10 @@ func (r *FileSystemRepository) GetBooks() *model.Books {
 	})
 
 	books.Info = r.info
+	books.Page = meta.Page{
+		Title:       "Books | Lean Thoughts",
+		Description: "Recommended books about lean thinking, software delivery, and team flow.",
+	}
 
 	return books
 }

--- a/internal/site/errors/controller/controller.go
+++ b/internal/site/errors/controller/controller.go
@@ -13,7 +13,13 @@ import (
 // normal requests and the partial fragment for PUT requests.
 func NewNotFound(info *site.Info, view *mvc.View, partialView *mvc.View) mvc.NotFoundController[model.NotFound] {
 	return func(ctx context.Context) (*mvc.View, *model.NotFound) {
-		notFound := &model.NotFound{Info: info}
+		notFound := &model.NotFound{
+			Info: info,
+			Page: site.Page{
+				Title:       "Page not found | Lean Thoughts",
+				Description: "The requested Lean Thoughts page could not be found.",
+			},
+		}
 		req := meta.Request(ctx)
 
 		switch req.Method {

--- a/internal/site/errors/model/doc.go
+++ b/internal/site/errors/model/doc.go
@@ -1,5 +1,5 @@
 // Package model defines view models for the error feature.
 //
 // The types in this package are rendered by the not-found templates and carry
-// shared site metadata into error responses.
+// shared site and page metadata into error responses.
 package model

--- a/internal/site/errors/model/model.go
+++ b/internal/site/errors/model/model.go
@@ -5,4 +5,5 @@ import "github.com/alexfalkowski/web/internal/site/meta"
 // NotFound is the view model rendered by the not-found page and fragment.
 type NotFound struct {
 	Info *meta.Info
+	Page meta.Page
 }

--- a/internal/site/meta/doc.go
+++ b/internal/site/meta/doc.go
@@ -1,8 +1,8 @@
 // Package meta provides shared, cross-cutting metadata used by site view models.
 //
 // The types in this package are used to enrich models with information that is
-// common across pages, such as the running service version and the current year
-// for rendering in templates (for example in footers or page headers).
+// common across pages, such as the running service version and the current year,
+// and page-specific document metadata for rendering in templates.
 //
 // Values are typically constructed via dependency injection:
 //
@@ -12,6 +12,7 @@
 // # Public API
 //
 //   - Year represents the current calendar year.
+//   - Page contains document metadata for a specific rendered page.
 //   - Info contains metadata shared by multiple site models (Version and Year).
 //   - NewYear and NewInfo are constructors intended to be used by the DI graph.
 //

--- a/internal/site/meta/meta.go
+++ b/internal/site/meta/meta.go
@@ -20,6 +20,15 @@ func NewYear() Year {
 // It is used as display metadata in templates (for example in a footer).
 type Year int
 
+// Page contains document metadata for a specific rendered page.
+type Page struct {
+	// Title is rendered as the page's HTML document title.
+	Title string
+
+	// Description is rendered as the page's HTML meta description.
+	Description string
+}
+
 // NewInfo constructs an Info value from the service version and year.
 //
 // The returned value is intended to be shared across multiple page models so

--- a/internal/site/root/controller/controller.go
+++ b/internal/site/root/controller/controller.go
@@ -11,7 +11,13 @@ import (
 // metadata.
 func NewRoot(info *meta.Info, view *mvc.View) mvc.Controller[model.Root] {
 	return func(_ context.Context) (*mvc.View, *model.Root, error) {
-		root := &model.Root{Info: info}
+		root := &model.Root{
+			Info: info,
+			Page: meta.Page{
+				Title:       "Lean Thoughts",
+				Description: "Lean Thoughts shares ideas about lean thinking and continuous improvement.",
+			},
+		}
 
 		return view, root, nil
 	}

--- a/internal/site/root/layout/full.tmpl
+++ b/internal/site/root/layout/full.tmpl
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Lean Thoughts</title>
+    <title>{{.Model.Page.Title}}</title>
+    <meta id="description" name="description" content="{{.Model.Page.Description}}">
     <link rel="icon" href="/favicon.ico" type="image/png">
     <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js" integrity="sha384-/TgkGk7p307TH7EXJDuUlgG3Ce1UVolAOFopFekQkkXihi5u/6OCvVKyz1W+idaz" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.1.1/css/pico.classless.min.css" />

--- a/internal/site/root/layout/partial.tmpl
+++ b/internal/site/root/layout/partial.tmpl
@@ -1,1 +1,3 @@
+<title>{{.Model.Page.Title}}</title>
+<meta id="description" name="description" content="{{.Model.Page.Description}}" hx-swap-oob="true">
 {{ block "content" . }}{{ end }}

--- a/internal/site/root/model/doc.go
+++ b/internal/site/root/model/doc.go
@@ -2,8 +2,8 @@
 //
 // The types in this package represent the view model rendered by the root page
 // templates. They are populated by the root controllers and are intentionally
-// small: the root page primarily needs shared site metadata (see the meta
-// package) to render things like the running version and current year.
+// small: the root page primarily needs shared site metadata and page document
+// metadata (see the meta package).
 //
 // # Public API
 //

--- a/internal/site/root/model/model.go
+++ b/internal/site/root/model/model.go
@@ -5,4 +5,5 @@ import "github.com/alexfalkowski/web/internal/site/meta"
 // Root is the view model rendered by the home page and fragment.
 type Root struct {
 	Info *meta.Info
+	Page meta.Page
 }

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -33,6 +33,21 @@ EXPECTED_PAGE_TEXT = {
   'books' => 'Margaret Fuller'
 }.freeze
 
+EXPECTED_PAGE_METADATA = {
+  'root' => {
+    title: 'Lean Thoughts',
+    description: 'Lean Thoughts shares ideas about lean thinking and continuous improvement.'
+  },
+  'books' => {
+    title: 'Books | Lean Thoughts',
+    description: 'Recommended books about lean thinking, software delivery, and team flow.'
+  },
+  'missing' => {
+    title: 'Page not found | Lean Thoughts',
+    description: 'The requested Lean Thoughts page could not be found.'
+  }
+}.freeze
+
 EXPECTED_NAV_LINKS = [
   { selector: 'a[href="/"][hx-put="/"]', text: 'Home' },
   { selector: 'a[href="/books"][hx-put="/books"]', text: 'Books' }
@@ -65,6 +80,7 @@ Then('I should see {string}') do |section|
   html = Nokogiri::HTML.parse(@response.body)
 
   expect_page_text(section, html)
+  expect_page_metadata(section, html, @layout)
   expect_books(html) if section == 'books'
   expect_layout(html)
 end
@@ -119,6 +135,7 @@ Then('I should see the page is missing with layout {string}') do |layout|
   html = Nokogiri::HTML.parse(@response.body)
 
   expect(html.text).to include('Page not found')
+  expect_page_metadata('missing', html, layout)
   expect(html.text.include?('Copyright')).to eq(layout == 'full')
 end
 
@@ -130,6 +147,28 @@ end
 
 def expect_page_text(section, html)
   expect(html.text).to include(EXPECTED_PAGE_TEXT.fetch(section))
+end
+
+def expect_page_metadata(section, html, layout)
+  metadata = EXPECTED_PAGE_METADATA.fetch(section)
+
+  expect_page_title(html, metadata)
+  expect_page_description(html, metadata, layout)
+end
+
+def expect_page_title(html, metadata)
+  title = html.at_css('title')
+
+  expect(title).not_to be_nil
+  expect(title.text).to eq(metadata.fetch(:title))
+end
+
+def expect_page_description(html, metadata, layout)
+  description = html.at_css('meta[name="description"]')
+
+  expect(description).not_to be_nil
+  expect(description[:content]).to eq(metadata.fetch(:description))
+  expect(description[:'hx-swap-oob']).to eq('true') if layout == 'partial'
 end
 
 def expect_books(html)


### PR DESCRIPTION
## What

- Add page-specific document titles and descriptions for the home, books, and not-found pages.
- Include metadata in full page renders and HTMX partial responses so browser tab text and the document description stay aligned during partial navigation.
- Keep the existing partial content swap behavior while using an out-of-band description update for the document head.

## Why

- Pages previously shared the same generic title and no description, making browser tabs, history, bookmarks, and shared/indexed pages harder to distinguish.
- HTMX navigation needs the same metadata updates as direct page loads so users see consistent page identity without a full reload.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `git diff --check` - passed
- Manual Chrome verification confirmed HTMX navigation updates `document.title` and `meta[name="description"]` without leaving metadata inside `#main`.

AI-assisted-by: [Codex](https://openai.com/codex/)
