### PR TITLE
feat(sitemap): publish crawler page inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ At a high level the service:
 - serves the home page (`/`)
 - serves a books page (`/books`)
 - serves `robots.txt` (`/robots.txt`)
+- serves `sitemap.xml` (`/sitemap.xml`)
 - serves the favicon (`/favicon.ico`)
 - renders a custom not-found page for missing routes
 - adds browser security headers to site responses
 - exposes health, liveness/readiness, and metrics endpoints
 
-The HTML templates, error templates, books YAML data, favicon image, and robots file are embedded into the binary using `go:embed`. Full-page browser rendering also loads HTMX and Pico CSS from jsDelivr, with those origins allowed by the response CSP.
+The HTML templates, error templates, books YAML data, favicon image, robots file, and sitemap are embedded into the binary using `go:embed`. Full-page browser rendering also loads HTMX and Pico CSS from jsDelivr, with those origins allowed by the response CSP.
 
 ## 🏗️ Architecture overview
 
@@ -61,7 +62,7 @@ Routing and rendering are handled using:
 
 - `go-service/v2/net/http/mvc`
 
-Feature modules (e.g. books/root/robots) register their routes during DI wiring.
+Feature modules (e.g. books/root/robots/sitemap) register their routes during DI wiring.
 
 ### 📦 Embedded assets
 
@@ -71,6 +72,7 @@ The site package embeds:
 - the books YAML file used to render the books page
 - the favicon PNG
 - `robots.txt`
+- `sitemap.xml`
 
 See:
 
@@ -85,6 +87,7 @@ See:
 - `GET /books` renders the books page
 - `PUT /books` renders a partial/fragment version of the books page
 - `GET /robots.txt` serves the robots file as a static asset
+- `GET /sitemap.xml` serves the sitemap file as a static asset
 - `GET /favicon.ico` serves the browser favicon
 - missing routes render a `404` not-found page
 
@@ -114,7 +117,7 @@ Site responses include browser security headers such as `Content-Security-Policy
 The CSP intentionally permits jsDelivr for HTMX and Pico CSS, plus Cloudflare Insights script and beacon origins (`static.cloudflareinsights.com` and `cloudflareinsights.com`) for production browser analytics.
 
 > [!NOTE]
-> The acceptance suite verifies these headers for the page, robots, favicon, and not-found responses.
+> The acceptance suite verifies these headers for the page, robots, sitemap, favicon, and not-found responses.
 
 ## 🧰 Development
 
@@ -233,6 +236,7 @@ Pages:
 curl -i http://localhost:11000/
 curl -i http://localhost:11000/books
 curl -i http://localhost:11000/robots.txt
+curl -i http://localhost:11000/sitemap.xml
 curl -i http://localhost:11000/favicon.ico
 ```
 

--- a/internal/site/module.go
+++ b/internal/site/module.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alexfalkowski/web/internal/site/robots"
 	"github.com/alexfalkowski/web/internal/site/root"
 	"github.com/alexfalkowski/web/internal/site/security"
+	"github.com/alexfalkowski/web/internal/site/sitemap"
 )
 
 // Module wires this package into the dependency graph.
@@ -20,6 +21,7 @@ var Module = di.Module(
 	robots.Module,
 	root.Module,
 	security.Module,
+	sitemap.Module,
 	di.Constructor(NewFileSystem),
 	di.Constructor(NewLayout),
 )

--- a/internal/site/robots/robots.txt
+++ b/internal/site/robots/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Sitemap: https://web.lean-thoughts.com/sitemap.xml

--- a/internal/site/site.go
+++ b/internal/site/site.go
@@ -14,6 +14,7 @@ import (
 //go:embed books/repository/*.yaml
 //go:embed favicon/*.png
 //go:embed robots/*.txt
+//go:embed sitemap/*.xml
 var filesystem embed.FS
 
 // NewFileSystem returns an `fs.FS` backed by the site's embedded assets.

--- a/internal/site/sitemap/doc.go
+++ b/internal/site/sitemap/doc.go
@@ -1,0 +1,17 @@
+// Package sitemap registers the site's sitemap.xml endpoint.
+//
+// The sitemap.xml file lists the site's canonical public URLs for search
+// engines and other crawlers. This package exposes it as a static file at:
+//
+//   - GET /sitemap.xml
+//
+// The file content is bundled with the binary through the site embedded
+// filesystem, allowing the service to run without relying on external assets at
+// runtime.
+//
+// # Public API
+//
+// Register installs the static route for /sitemap.xml on the global MVC router.
+// It is typically invoked via dependency injection (see this package's Module)
+// rather than being called directly by application code.
+package sitemap

--- a/internal/site/sitemap/module.go
+++ b/internal/site/sitemap/module.go
@@ -1,0 +1,8 @@
+package sitemap
+
+import "github.com/alexfalkowski/go-service/v2/di"
+
+// Module wires this package into the dependency graph.
+var Module = di.Module(
+	di.Register(Register),
+)

--- a/internal/site/sitemap/sitemap.go
+++ b/internal/site/sitemap/sitemap.go
@@ -1,0 +1,8 @@
+package sitemap
+
+import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
+
+// Register installs the static sitemap.xml route on the global MVC router.
+func Register() {
+	mvc.StaticFile("/sitemap.xml", "sitemap/sitemap.xml")
+}

--- a/internal/site/sitemap/sitemap.xml
+++ b/internal/site/sitemap/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://web.lean-thoughts.com/</loc>
+  </url>
+  <url>
+    <loc>https://web.lean-thoughts.com/books</loc>
+  </url>
+</urlset>

--- a/test/features/site/site.feature
+++ b/test/features/site/site.feature
@@ -18,6 +18,10 @@ Feature: Web
     When I visit the robots file
     Then I should see the robots file
 
+  Scenario: Visit sitemap
+    When I visit the sitemap file
+    Then I should see the sitemap file
+
   Scenario: Visit favicon
     When I visit the favicon
     Then I should see the favicon

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -48,6 +48,13 @@ EXPECTED_PAGE_METADATA = {
   }
 }.freeze
 
+EXPECTED_SITEMAP_URLS = [
+  'https://web.lean-thoughts.com/',
+  'https://web.lean-thoughts.com/books'
+].freeze
+
+SITEMAP_URL = 'https://web.lean-thoughts.com/sitemap.xml'
+
 EXPECTED_NAV_LINKS = [
   { selector: 'a[href="/"][hx-put="/"]', text: 'Home' },
   { selector: 'a[href="/books"][hx-put="/books"]', text: 'Books' }
@@ -91,6 +98,12 @@ When('I visit the robots file') do
   @response = Web::V1.http.get_robots(opts)
 end
 
+When('I visit the sitemap file') do
+  opts = Web.http_options(headers: { user_agent: 'Web-client/1.0 HTTP/1.0' })
+
+  @response = Web::V1.http.get_sitemap(opts)
+end
+
 When('I visit the favicon') do
   opts = Web.http_options(headers: { user_agent: 'Web-client/1.0 HTTP/1.0' })
 
@@ -102,6 +115,18 @@ Then('I should see the robots file') do
   expect(@response.headers[:content_type]).to eq('text/plain; charset=utf-8')
   expect_security_headers(@response)
   expect(@response.body).to include('User-agent: *')
+  expect(@response.body).to include("Sitemap: #{SITEMAP_URL}")
+end
+
+Then('I should see the sitemap file') do
+  expect(@response.code).to eq(200)
+  expect(@response.headers[:content_type]).to eq('text/xml; charset=utf-8')
+  expect_security_headers(@response)
+
+  xml = Nokogiri::XML.parse(@response.body)
+  urls = xml.css('url loc').map(&:text)
+
+  expect(urls).to eq(EXPECTED_SITEMAP_URLS)
 end
 
 Then('I should see the favicon') do

--- a/test/lib/web/v1/http.rb
+++ b/test/lib/web/v1/http.rb
@@ -54,6 +54,14 @@ module Web
         get('/robots.txt', opts)
       end
 
+      # GET the sitemap.xml file.
+      #
+      # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#get}
+      # @return [Object] the response returned by the underlying HTTP client
+      def get_sitemap(opts = {})
+        get('/sitemap.xml', opts)
+      end
+
       # GET the browser favicon.
       #
       # @param opts [Hash] request options forwarded to {Nonnative::HTTPClient#get}


### PR DESCRIPTION
## What

- Add a static `/sitemap.xml` endpoint listing the root and books canonical URLs.
- Advertise the endpoint from `robots.txt` and document it in the README endpoint and asset references.
- Cover the crawler-facing response and robots directive in the Cucumber site feature.

## Why

- Gives crawlers and operators a machine-readable inventory of public pages without relying only on HTML link discovery.
- Keeps crawler-facing docs and acceptance coverage aligned with shipped service behavior.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
