### PR TITLE
feat(books): add recommendation context

### DIFF
--- a/internal/site/books/model/model.go
+++ b/internal/site/books/model/model.go
@@ -2,17 +2,18 @@ package model
 
 import "github.com/alexfalkowski/web/internal/site/meta"
 
-type (
-	// Books is the view model rendered by the books page.
-	Books struct {
-		Info  *meta.Info `yaml:"-"`
-		Page  meta.Page  `yaml:"-"`
-		Books []*Book    `yaml:"books,omitempty"`
-	}
+// Books is the view model rendered by the books page.
+type Books struct {
+	Info  *meta.Info `yaml:"-"`
+	Page  meta.Page  `yaml:"-"`
+	Books []*Book    `yaml:"books,omitempty"`
+}
 
-	// Book describes one book link loaded from the embedded YAML content.
-	Book struct {
-		Title string `yaml:"title,omitempty"`
-		Link  string `yaml:"link,omitempty"`
-	}
-)
+// Book describes one book recommendation loaded from the embedded YAML content.
+type Book struct {
+	Title  string `yaml:"title,omitempty"`
+	Author string `yaml:"author,omitempty"`
+	Topics string `yaml:"topics,omitempty"`
+	Note   string `yaml:"note,omitempty"`
+	Link   string `yaml:"link,omitempty"`
+}

--- a/internal/site/books/repository/books.yaml
+++ b/internal/site/books/repository/books.yaml
@@ -2,10 +2,19 @@
 books:
   -
     title: "Kanban: Successful Evolutionary Change for Your Technology Business"
+    author: "David J. Anderson"
+    topics: "Kanban, evolutionary change, flow"
+    note: "A practical introduction to improving delivery with visual work management and evolutionary change."
     link: "https://www.amazon.de/-/en/David-J-Anderson/dp/0984521402"
   -
     title: "Team Topologies: Organizing Business and Technology Teams for Fast Flow"
+    author: "Matthew Skelton and Manuel Pais"
+    topics: "team design, cognitive load, flow"
+    note: "Explains how team structures and interaction modes shape software delivery outcomes."
     link: "https://www.amazon.de/-/en/Team-Topologies-Organizing-Business-Technology/dp/1942788819"
   -
     title: "Modern Software Engineering: Doing What Works to Build Better Software Faster"
+    author: "David Farley"
+    topics: "software engineering, continuous delivery, quality"
+    note: "Connects engineering discipline with fast feedback, learning, and reliable software delivery."
     link: "https://www.amazon.de/-/en/Modern-Software-Engineering-Better-Faster/dp/0137314914"

--- a/internal/site/books/view/books.tmpl
+++ b/internal/site/books/view/books.tmpl
@@ -14,6 +14,9 @@
       <thead>
         <tr>
           <th scope="col">Title</th>
+          <th scope="col">Author</th>
+          <th scope="col">Topics</th>
+          <th scope="col">Why</th>
           <th scope="col">Link</th>
         </tr>
       </thead>
@@ -21,6 +24,9 @@
         {{range .Model.Books}}
           <tr>
             <td>{{.Title}}</td>
+            <td>{{.Author}}</td>
+            <td>{{.Topics}}</td>
+            <td>{{.Note}}</td>
             <td><a href="{{.Link}}" target="_blank" rel="noopener noreferrer">{{.Link}}</a></td>
           </tr>
         {{end}}

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -16,17 +16,28 @@ SECURITY_HEADERS = {
 EXPECTED_BOOKS = [
   {
     title: 'Kanban: Successful Evolutionary Change for Your Technology Business',
+    author: 'David J. Anderson',
+    topics: 'Kanban, evolutionary change, flow',
+    note: 'A practical introduction to improving delivery with visual work management and evolutionary change.',
     link: 'https://www.amazon.de/-/en/David-J-Anderson/dp/0984521402'
   },
   {
     title: 'Modern Software Engineering: Doing What Works to Build Better Software Faster',
+    author: 'David Farley',
+    topics: 'software engineering, continuous delivery, quality',
+    note: 'Connects engineering discipline with fast feedback, learning, and reliable software delivery.',
     link: 'https://www.amazon.de/-/en/Modern-Software-Engineering-Better-Faster/dp/0137314914'
   },
   {
     title: 'Team Topologies: Organizing Business and Technology Teams for Fast Flow',
+    author: 'Matthew Skelton and Manuel Pais',
+    topics: 'team design, cognitive load, flow',
+    note: 'Explains how team structures and interaction modes shape software delivery outcomes.',
     link: 'https://www.amazon.de/-/en/Team-Topologies-Organizing-Business-Technology/dp/1942788819'
   }
 ].freeze
+
+EXPECTED_BOOK_HEADERS = %w[Title Author Topics Why Link].freeze
 
 EXPECTED_PAGE_TEXT = {
   'root' => 'Vince Lombardi',
@@ -197,7 +208,12 @@ def expect_page_description(html, metadata, layout)
 end
 
 def expect_books(html)
+  expect(book_headers(html)).to eq(EXPECTED_BOOK_HEADERS)
   expect(book_rows(html)).to eq(EXPECTED_BOOKS)
+end
+
+def book_headers(html)
+  html.css('thead th').map(&:text)
 end
 
 def book_rows(html)
@@ -206,9 +222,15 @@ end
 
 def book_row(row)
   cells = row.css('td')
-  link = cells[1].at_css('a')
+  link = cells[4].at_css('a')
 
-  { title: cells[0].text, link: link[:href] }
+  {
+    title: cells[0].text,
+    author: cells[1].text,
+    topics: cells[2].text,
+    note: cells[3].text,
+    link: link[:href]
+  }
 end
 
 def expect_layout(html)


### PR DESCRIPTION
## What

- Add author, topic, and recommendation note context to the existing book recommendations.
- Render the added context in the Books table while preserving the existing external links and alphabetical sorting.
- Extend the Cucumber site assertions to verify the new columns and row content for full and partial Books renders.

## Why

- Helps visitors decide which recommendation is relevant before opening an external Amazon link.
- Keeps curated book content in the existing embedded YAML source so the page remains easy to maintain.

## Testing

- `make lint` - passed
- `make features` - passed
- `make benchmarks` - passed
- `make sec` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
