### PR TITLE
feat(static): cache embedded assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Site responses include browser security headers such as `Content-Security-Policy
 
 The CSP intentionally permits jsDelivr for HTMX and Pico CSS, plus Cloudflare Insights script and beacon origins (`static.cloudflareinsights.com` and `cloudflareinsights.com`) for production browser analytics.
 
+Embedded static assets also include `Cache-Control` and `ETag` headers, and matching `If-None-Match` requests return `304 Not Modified`.
+
 > [!NOTE]
 > The acceptance suite verifies these headers for the page, robots, sitemap, favicon, and not-found responses.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.29.0
-	github.com/alexfalkowski/go-service/v2 v2.596.0
+	github.com/alexfalkowski/go-service/v2 v2.597.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.29.0 h1:ZXkXalGX4u5DZR6eZAySpXCb1UUAvq+ufD1Eq+kKUv8=
 github.com/alexfalkowski/go-health/v2 v2.29.0/go.mod h1:oIzLvkIhiXUbPSYQRW2Gezah+sW+ZEY9BcoOi/5Agxo=
-github.com/alexfalkowski/go-service/v2 v2.596.0 h1:55EICbWETxXh9fvJ++RG7Hea4PQIALLMZyQspTQn8aY=
-github.com/alexfalkowski/go-service/v2 v2.596.0/go.mod h1:bfFj9FyvRoviXOV3cyTBcFPoLFkmD3grvE1dhFzAeYQ=
+github.com/alexfalkowski/go-service/v2 v2.597.0 h1:KY2ukioIm04SfkRAPy5TYAx57ZcUHtQh9h6KSw6pn1E=
+github.com/alexfalkowski/go-service/v2 v2.597.0/go.mod h1:bfFj9FyvRoviXOV3cyTBcFPoLFkmD3grvE1dhFzAeYQ=
 github.com/alexfalkowski/go-sync v1.24.0 h1:CrV+LITc8C78v01u9ATGvIgipmNtJlZWGWW1znFsdjM=
 github.com/alexfalkowski/go-sync v1.24.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/internal/site/favicon/favicon.go
+++ b/internal/site/favicon/favicon.go
@@ -4,5 +4,10 @@ import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
 // Register installs the static favicon route on the global MVC router.
 func Register() {
-	mvc.StaticFile("/favicon.ico", "favicon/favicon.png")
+	mvc.StaticFile(
+		"/favicon.ico",
+		"favicon/favicon.png",
+		mvc.WithCacheControl("public, max-age=3600"),
+		mvc.WithCacheValidators(),
+	)
 }

--- a/internal/site/robots/robots.go
+++ b/internal/site/robots/robots.go
@@ -4,5 +4,10 @@ import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
 // Register installs the static robots.txt route on the global MVC router.
 func Register() {
-	mvc.StaticFile("/robots.txt", "robots/robots.txt")
+	mvc.StaticFile(
+		"/robots.txt",
+		"robots/robots.txt",
+		mvc.WithCacheControl("public, max-age=3600"),
+		mvc.WithCacheValidators(),
+	)
 }

--- a/internal/site/sitemap/sitemap.go
+++ b/internal/site/sitemap/sitemap.go
@@ -4,5 +4,10 @@ import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
 
 // Register installs the static sitemap.xml route on the global MVC router.
 func Register() {
-	mvc.StaticFile("/sitemap.xml", "sitemap/sitemap.xml")
+	mvc.StaticFile(
+		"/sitemap.xml",
+		"sitemap/sitemap.xml",
+		mvc.WithCacheControl("public, max-age=3600"),
+		mvc.WithCacheValidators(),
+	)
 }

--- a/test/features/step_definitions/site/site_steps.rb
+++ b/test/features/step_definitions/site/site_steps.rb
@@ -125,6 +125,7 @@ Then('I should see the robots file') do
   expect(@response.code).to eq(200)
   expect(@response.headers[:content_type]).to eq('text/plain; charset=utf-8')
   expect_security_headers(@response)
+  expect_static_cache { |opts| Web::V1.http.get_robots(opts) }
   expect(@response.body).to include('User-agent: *')
   expect(@response.body).to include("Sitemap: #{SITEMAP_URL}")
 end
@@ -133,6 +134,7 @@ Then('I should see the sitemap file') do
   expect(@response.code).to eq(200)
   expect(@response.headers[:content_type]).to eq('text/xml; charset=utf-8')
   expect_security_headers(@response)
+  expect_static_cache { |opts| Web::V1.http.get_sitemap(opts) }
 
   xml = Nokogiri::XML.parse(@response.body)
   urls = xml.css('url loc').map(&:text)
@@ -144,6 +146,7 @@ Then('I should see the favicon') do
   expect(@response.code).to eq(200)
   expect(@response.headers[:content_type]).to eq('image/png')
   expect_security_headers(@response)
+  expect_static_cache { |opts| Web::V1.http.get_favicon(opts) }
   expect(@response.body.bytes.first(8)).to eq([137, 80, 78, 71, 13, 10, 26, 10])
 end
 
@@ -179,6 +182,32 @@ def expect_security_headers(response)
   SECURITY_HEADERS.each do |header, value|
     expect(response.headers[header]).to eq(value)
   end
+end
+
+def expect_static_cache(&)
+  etag = expect_static_cache_headers(@response)
+
+  expect_static_cache_revalidation(etag, &)
+end
+
+def expect_static_cache_headers(response)
+  etag = response.headers[:etag]
+
+  expect(response.headers[:cache_control]).to eq('public, max-age=3600')
+  expect(etag).not_to be_nil
+
+  etag
+end
+
+def expect_static_cache_revalidation(etag)
+  opts = Web.http_options(headers: {
+                            user_agent: 'Web-client/1.0 HTTP/1.0',
+                            if_none_match: etag
+                          })
+  response = yield(opts)
+
+  expect(response.code).to eq(304)
+  expect(response.body).to be_empty
 end
 
 def expect_page_text(section, html)


### PR DESCRIPTION
## What

- Add cache-control and ETag validators to embedded favicon, robots, and sitemap assets.
- Document the static asset cache validator behavior in the README.
- Extend the site acceptance checks to verify cache headers and `If-None-Match` revalidation returns `304 Not Modified`.

## Why

- Browsers and crawlers can avoid re-downloading stable embedded assets once they have a matching validator.
- The behavior stays on the shared MVC static-file path instead of adding repository-local hashing or buffering.

## Testing

- `gmake lint` - passed
- `gmake sec` - passed
- `gmake build` - passed
- `gmake features` - passed
- `gmake benchmarks` - passed
- The updated site scenarios cover robots, sitemap, and favicon cache headers plus conditional ETag revalidation.

AI-assisted-by: [Codex](https://openai.com/codex/)
