### PR TITLE
docs(agents): prefer make command surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,9 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 
 ## First steps
 
-1. Ensure the `bin/` submodule is present before using Make targets:
-
-```sh
-git submodule sync
-git submodule update --init
-```
+1. Ensure the `bin/` submodule is present before using Make targets. Use
+   `make submodule` once the shared checkout is present; see `bin/AGENTS.md`
+   for fresh-clone bootstrap details.
 
 2. Install dependencies:
 
@@ -44,11 +41,7 @@ make help
 - `make sec` runs security checks.
 - `make coverage` generates coverage artifacts under `test/reports/`.
 
-If you build locally, start the service with:
-
-```sh
-./web server -config file:test/.config/server.yml
-```
+Use `make dev` for local runtime work through the repository command surface.
 
 ## Testing policy
 
@@ -56,8 +49,8 @@ If you build locally, start the service with:
   `test/features/`.
 - Treat `make features` and `make benchmarks` as the authoritative behavioral
   checks.
-- `go test ./...` and `make specs` exist for tooling/build support, but they are
-  not the primary product test signal in this repo.
+- `make specs` exists for tooling/build support, but it is not the primary
+  product test signal in this repo.
 
 ## Architecture
 
@@ -136,6 +129,6 @@ jobs.
 ## Gotchas
 
 - `bin/` is a required submodule; stale or missing checkout breaks many targets.
-- Tooling expects external binaries such as `air`, `golangci-lint`,
-  `govulncheck`, `bundler`, `rubocop`, and `cucumber`.
+- Some Make targets expect external tools on `PATH`; run them through the
+  repository targets instead of invoking those tools directly.
 - Field alignment only targets packages listed in `.gofa` (`internal` here).


### PR DESCRIPTION
## What

- Update the `bin` submodule to the shared guidance that centralizes Makefile-first command policy.
- Clean up local `AGENTS.md` guidance so repository instructions prefer Make targets instead of direct tool commands.
- Remove stale-prone runtime, toolchain, dependency, or image version claims from local agent guidance where they belonged in source files or CI configuration.

## Why

- Keeps command guidance aligned with the shared `bin/AGENTS.md` policy and avoids copying ad hoc commands across repositories.
- Reduces stale local agent instructions by leaving changing versions and tool details in their authoritative files.

## Testing

- `git diff --check` - passed
- `zsh -lic 'make lint'` - passed
- Direct-command guidance scan - passed
- Exact-version guidance scan - passed; remaining matches are IP address literals, not dependency, toolchain, or image versions.

AI-assisted-by: [Codex](https://openai.com/codex/)
