### PR TITLE
build(bin): refresh shared tooling guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,6 @@ CircleCI is the source of truth for required checks. The main service build job 
 - `make coverage`
 - `make codecov-upload`
 
-`make codecov-upload` is CI upload behavior, not a read-only local validation
-step.
-
 The non-`master` workflow also runs:
 
 - `make platform=amd64 test-docker`


### PR DESCRIPTION
## What

- Updates the `bin` submodule to the merged shared project-gap guidance changes.
- Removes local `AGENTS.md` exception text that is now covered by shared `bin/AGENTS.md`.

## Why

- Keeps downstream project-gap investigations focused on repository-specific issues instead of repeating shared workflow exceptions.
- Reduces duplicated maintainer guidance across repositories while preserving repo-specific notes.

## Testing

- `git diff --check` - passed
- `make help` - passed
- `make lint` - passed
