### PR TITLE
feat(site): centralize static asset cache policy

### DIFF
--- a/internal/site/favicon/favicon.go
+++ b/internal/site/favicon/favicon.go
@@ -1,13 +1,8 @@
 package favicon
 
-import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
+import "github.com/alexfalkowski/web/internal/site/static"
 
 // Register installs the static favicon route on the global MVC router.
 func Register() {
-	mvc.StaticFile(
-		"/favicon.ico",
-		"favicon/favicon.png",
-		mvc.WithCacheControl("public, max-age=3600"),
-		mvc.WithCacheValidators(),
-	)
+	static.File("/favicon.ico", "favicon/favicon.png")
 }

--- a/internal/site/robots/robots.go
+++ b/internal/site/robots/robots.go
@@ -1,13 +1,8 @@
 package robots
 
-import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
+import "github.com/alexfalkowski/web/internal/site/static"
 
 // Register installs the static robots.txt route on the global MVC router.
 func Register() {
-	mvc.StaticFile(
-		"/robots.txt",
-		"robots/robots.txt",
-		mvc.WithCacheControl("public, max-age=3600"),
-		mvc.WithCacheValidators(),
-	)
+	static.File("/robots.txt", "robots/robots.txt")
 }

--- a/internal/site/sitemap/sitemap.go
+++ b/internal/site/sitemap/sitemap.go
@@ -1,13 +1,8 @@
 package sitemap
 
-import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
+import "github.com/alexfalkowski/web/internal/site/static"
 
 // Register installs the static sitemap.xml route on the global MVC router.
 func Register() {
-	mvc.StaticFile(
-		"/sitemap.xml",
-		"sitemap/sitemap.xml",
-		mvc.WithCacheControl("public, max-age=3600"),
-		mvc.WithCacheValidators(),
-	)
+	static.File("/sitemap.xml", "sitemap/sitemap.xml")
 }

--- a/internal/site/static/doc.go
+++ b/internal/site/static/doc.go
@@ -1,0 +1,2 @@
+// Package static registers embedded static assets with the site's cache policy.
+package static

--- a/internal/site/static/static.go
+++ b/internal/site/static/static.go
@@ -1,0 +1,19 @@
+package static
+
+import "github.com/alexfalkowski/go-service/v2/net/http/mvc"
+
+const cacheControl = "public, max-age=3600"
+
+// File registers an embedded static asset with the site's cache policy.
+//
+// Keep the shared MVC weak metadata validator intentionally. The embedded
+// assets are stable between deploys, and this avoids repo-local hashing or
+// buffering.
+func File(pattern, name string) bool {
+	return mvc.StaticFile(
+		pattern,
+		name,
+		mvc.WithCacheControl(cacheControl),
+		mvc.WithCacheValidators(),
+	)
+}


### PR DESCRIPTION
## What

- Centralize embedded static asset cache registration behind a shared helper.
- Keep the robots, sitemap, and favicon routes on the same cache-control and weak validator behavior.
- Document that the weak metadata validator is intentional so future reviews do not reintroduce repository-local hashing or buffering.

## Why

- The static asset routes shared the same cache policy in three places, which made the intentional validator tradeoff easy to question repeatedly.
- A small helper keeps the route registrations focused on paths while preserving the existing public behavior.

## Testing

- `make lint` - passed
- `make features feature=features/site/site.feature` - passed
- The targeted site feature covers full and partial page rendering, static asset responses, cache headers, ETag revalidation, and missing route rendering.

AI-assisted-by: [Codex](https://openai.com/codex/)
