### PR TITLE
docs(readme): clarify service-prefixed operation routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,17 @@ See:
 
 ### 🫀 Health and observability
 
-The service registers health checks and exposes standard probe endpoints:
+The HTTP transport registers service-prefixed health and observability routes.
+With the local service name `web`, the endpoints are:
 
-- `/healthz` (overall health / online)
-- `/livez` (liveness)
-- `/readyz` (readiness)
-- `/metrics` (Prometheus metrics)
+- `/web/healthz` (overall health / online)
+- `/web/livez` (liveness)
+- `/web/readyz` (readiness)
+- `/web/metrics` (Prometheus metrics)
 
 Health timings are configured via the service config under the `health` section.
 
-`/healthz` uses the default `go-health/v2` online registration, so it can depend on public connectivity. `/livez` and `/readyz` use noop checks.
+`/web/healthz` uses the default `go-health/v2` online registration, so it can depend on public connectivity. `/web/livez` and `/web/readyz` use noop checks.
 
 ### 🛡️ Response headers
 
@@ -252,10 +253,10 @@ curl -i -X PUT http://localhost:11000/books
 Health:
 
 ```sh
-curl -i http://localhost:11000/healthz
-curl -i http://localhost:11000/livez
-curl -i http://localhost:11000/readyz
-curl -i http://localhost:11000/metrics
+curl -i http://localhost:11000/web/healthz
+curl -i http://localhost:11000/web/livez
+curl -i http://localhost:11000/web/readyz
+curl -i http://localhost:11000/web/metrics
 ```
 
 Not found:

--- a/internal/health/doc.go
+++ b/internal/health/doc.go
@@ -1,13 +1,14 @@
 // Package health configures and exposes health and liveness/readiness endpoints.
 //
 // This package registers health checks and HTTP observers against the service's
-// server, enabling standard Kubernetes-style probes:
+// server. The HTTP transport exposes those observers on service-prefixed
+// operation routes; for this service's local name, the routes are:
 //
-//   - /healthz   overall health (default online connectivity check)
-//   - /livez     liveness (noop)
-//   - /readyz    readiness (noop)
+//   - /web/healthz   overall health (default online connectivity check)
+//   - /web/livez     liveness (noop)
+//   - /web/readyz    readiness (noop)
 //
-// The /healthz observer is backed by go-health/v2's default online
+// The /web/healthz observer is backed by go-health/v2's default online
 // registration, so restricted public connectivity can affect the overall health
 // response. The liveness and readiness observers use noop registrations.
 //


### PR DESCRIPTION
## What

- Document the service-prefixed health and observability routes exposed by the HTTP transport.
- Update the local curl examples to use `/web/healthz`, `/web/livez`, `/web/readyz`, and `/web/metrics`.
- Align the health package documentation with the service-prefixed route contract while keeping the observer semantics unchanged.

## Why

- Operators following the README should be able to verify health, readiness, liveness, and metrics using the actual local routes.
- The Nonnative harness and go-service transport expose operation endpoints under the service name, so documenting bare `/healthz`-style paths was misleading.

## Testing

- `make lint` - passed
- `make features feature=features/health/observability.feature` - passed
- `make features` - passed
- `make benchmarks` - passed
